### PR TITLE
[feat/handle-exception] 공통 예외 처리 부분 구현

### DIFF
--- a/com.trillionares.tryit.config/build.gradle
+++ b/com.trillionares.tryit.config/build.gradle
@@ -28,6 +28,8 @@ ext {
 }
 
 dependencies {
+	implementation 'me.paulschwarz:spring-dotenv:4.0.0' // 환경변수 읽어오는 의존성
+
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-config-server'

--- a/com.trillionares.tryit.config/src/main/resources/application.yml
+++ b/com.trillionares.tryit.config/src/main/resources/application.yml
@@ -6,11 +6,15 @@ spring:
     active: native
   application:
     name: config-server
+  config:
+    import:
+      - optional:file:./environment/.env[.properties]
   cloud:
     config:
       server:
         native:
-          search-locations: classpath:/config-repo  # 리소스 폴더의 디렉토리 경로
+          search-locations:
+            - classpath:/config-repo  # 리소스 폴더의 디렉토리 경로
 
 eureka:
   client:

--- a/com.trillionares.tryit.config/src/main/resources/config-repo/notification-service.yml
+++ b/com.trillionares.tryit.config/src/main/resources/config-repo/notification-service.yml
@@ -1,0 +1,38 @@
+server:
+  port: 19050
+
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/trillionaires
+    username: notification
+    password: notification
+    driver-class-name: org.postgresql.Driver
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: '*'
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+#  data:
+#    redis:
+#      host: ${redis.notification.host}
+#      port: ${redis.notification.port}
+#      password: ${redis.common.password}
+#
+#management:
+#  server:
+#    port: ${monitoring.prometheus.notification-port}
+
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true

--- a/com.trillionares.tryit.notification/build.gradle
+++ b/com.trillionares.tryit.notification/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	runtimeOnly 'org.postgresql:postgresql'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/libs/exception/ErrorCode.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/libs/exception/ErrorCode.java
@@ -1,0 +1,40 @@
+package com.trillionares.tryit.notification.libs.exception;
+
+public enum ErrorCode {
+
+  // 클라이언트 오류 (4xx)
+  INVALID_INPUT_VALUE(400, "입력값이 올바르지 않습니다"),
+  INVALID_TYPE_VALUE(400, "타입이 올바르지 않습니다"),
+  ENTITY_NOT_FOUND(400, "엔티티를 찾을 수 없습니다"),
+  INVALID_PASSWORD(400, "비밀번호가 올바르지 않습니다"),
+  FORBIDDEN(403, "접근 권한이 없습니다"),
+  UNAUTHORIZED(401, "인증되지 않은 접근입니다"),
+
+  // 서버 오류 (5xx)
+  INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다"),
+  DATABASE_ERROR(500, "데이터베이스 오류가 발생했습니다"),
+  FILE_PROCESSING_ERROR(500, "파일 처리 중 오류가 발생했습니다"),
+  EXTERNAL_SERVICE_ERROR(500, "외부 서비스 연동 중 오류가 발생했습니다"),
+
+  // 데이터 검증 관련
+  INVALID_LENGTH(400, "길이가 올바르지 않습니다"),
+  INVALID_FORMAT(400, "형식이 올바르지 않습니다"),
+  INVALID_RANGE(400, "범위가 올바르지 않습니다"),
+  INVALID_DATE(400, "날짜가 올바르지 않습니다");
+
+  private final int status;
+  private final String message;
+
+  ErrorCode(int status, String message) {
+    this.status = status;
+    this.message = message;
+  }
+
+  public int getStatus() {
+    return status;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/libs/exception/ErrorResponse.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/libs/exception/ErrorResponse.java
@@ -1,0 +1,52 @@
+package com.trillionares.tryit.notification.libs.exception;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 클라이언트에 반환하는 에러 형식을 정의하는 클래스
+ */
+@Getter
+public class ErrorResponse {
+
+  private final LocalDateTime timestamp = LocalDateTime.now();
+  private final int status;
+  private final String message;
+  private final String path;
+  private final List<FieldError> errors;
+
+  @Builder
+  private ErrorResponse(int status, String message, String path, List<FieldError> errors) {
+    this.status = status;
+    this.message = message;
+    this.path = path;
+    this.errors = errors;
+  }
+
+  @Getter
+  @Builder
+  public static class FieldError {
+    private final String field;
+    private final String value;
+    private final String reason;
+  }
+
+  public static ErrorResponse of(ErrorCode errorCode, String path) {
+    return ErrorResponse.builder()
+        .status(errorCode.getStatus())
+        .message(errorCode.getMessage())
+        .path(path)
+        .build();
+  }
+
+  public static ErrorResponse of(ErrorCode errorCode, String path, List<FieldError> errors) { // validation에서 에러가 나는 경우
+    return ErrorResponse.builder()
+        .status(errorCode.getStatus())
+        .message(errorCode.getMessage())
+        .path(path)
+        .errors(errors)
+        .build();
+  }
+}

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/libs/exception/ExceptionConverter.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/libs/exception/ExceptionConverter.java
@@ -1,0 +1,31 @@
+package com.trillionares.tryit.notification.libs.exception;
+
+import java.net.ConnectException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Checked Exception이 발생했을 때 Global Exception으로 변환하는 클래스
+ */
+@Slf4j
+@Component
+public class ExceptionConverter {
+
+  public GlobalException convertToBaseException(Exception e) {
+    log.info("Converting checked exception to unchecked", e);
+
+    if (e instanceof ConnectException) {
+      log.warn("Slack connection failed: {}", e.getMessage());
+      return new GlobalException(
+          ErrorCode.EXTERNAL_SERVICE_ERROR,
+          "Slack 서버 연결 실패: " + e.getMessage()
+      );
+    }
+
+    // 기타 예외 처리
+    return new GlobalException(
+        ErrorCode.INTERNAL_SERVER_ERROR,
+        "알 수 없는 오류가 발생했습니다: " + e.getMessage()
+    );
+  }
+}

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/libs/exception/GlobalException.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/libs/exception/GlobalException.java
@@ -1,0 +1,20 @@
+package com.trillionares.tryit.notification.libs.exception;
+
+public class GlobalException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public GlobalException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
+  public GlobalException(ErrorCode errorCode, String message) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+
+  public ErrorCode getErrorCode() {
+    return errorCode;
+  }
+}

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/libs/exception/GlobalExceptionHandler.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/libs/exception/GlobalExceptionHandler.java
@@ -1,0 +1,101 @@
+package com.trillionares.tryit.notification.libs.exception;
+
+import com.trillionares.tryit.notification.libs.exception.ErrorResponse.FieldError;
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.file.AccessDeniedException;
+import java.util.List;
+import javax.naming.AuthenticationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(GlobalException.class)
+  public ResponseEntity<ErrorResponse> handleCustomException(
+      GlobalException e,
+      HttpServletRequest request) {
+    ErrorCode errorCode = e.getErrorCode();
+    log.error("GlobalException occurred : ErrorCode = {} message = {} path = {}",
+        errorCode.name(), errorCode.getMessage(), request.getRequestURI());
+
+    return ResponseEntity
+        .status(errorCode.getStatus())
+        .body(ErrorResponse.of(errorCode, request.getRequestURI()));
+  }
+
+  /**
+   * 유효성 검증에 실패했을때 발생하는 예외를 처리합니다.
+   * 모든 필드 오류를 수집해 여러개의 오류가 있는 경우 한번에 반환합니다.
+   *
+   * @param e Spring Framework에서 발생시킨 유효성 검증 예외
+   * @param request 현재 HTTP 요청
+   * @return 필드 오류 목록이 포함된 에러 응답
+   */
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(
+      MethodArgumentNotValidException e,
+      HttpServletRequest request) {
+
+    List<FieldError> fieldErrors = e.getBindingResult()
+        .getFieldErrors()
+        .stream()
+        .map(error -> ErrorResponse.FieldError.builder()
+            .field(error.getField())
+            .value(String.valueOf(error.getRejectedValue()))
+            .reason(error.getDefaultMessage())
+            .build())
+        .toList();
+
+    return ResponseEntity
+        .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
+        .body(ErrorResponse.of(
+            ErrorCode.INVALID_INPUT_VALUE,
+            request.getRequestURI(),
+            fieldErrors));
+  }
+
+  // 접근 권한 없음
+  @ExceptionHandler(AccessDeniedException.class)
+  public ResponseEntity<ErrorResponse> handleAccessDenied(
+      AccessDeniedException e,
+      HttpServletRequest request
+  ) {
+    return ResponseEntity
+        .status(ErrorCode.FORBIDDEN.getStatus())
+        .body(ErrorResponse.of(
+            ErrorCode.FORBIDDEN,
+            request.getRequestURI()));
+  }
+
+  // 인증 실패
+  @ExceptionHandler(AuthenticationException.class)
+  public ResponseEntity<ErrorResponse> handleAuthenticationException(
+      AuthenticationException e,
+      HttpServletRequest request
+   ) {
+    return ResponseEntity
+        .status(ErrorCode.UNAUTHORIZED.getStatus())
+        .body(ErrorResponse.of(
+            ErrorCode.UNAUTHORIZED,
+            request.getRequestURI()));
+  }
+
+  // 그외 예외 처리
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleException(
+      Exception e,
+      HttpServletRequest request) {
+    log.error("Unexpected Exception occurred", e);
+
+    return ResponseEntity
+        .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+        .body(ErrorResponse.of(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            request.getRequestURI()));
+  }
+}

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/libs/exception/GlobalExceptionHandler.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/libs/exception/GlobalExceptionHandler.java
@@ -65,6 +65,8 @@ public class GlobalExceptionHandler {
       AccessDeniedException e,
       HttpServletRequest request
   ) {
+    log.error("Access denied: {}", e.getMessage());
+
     return ResponseEntity
         .status(ErrorCode.FORBIDDEN.getStatus())
         .body(ErrorResponse.of(
@@ -78,6 +80,8 @@ public class GlobalExceptionHandler {
       AuthenticationException e,
       HttpServletRequest request
    ) {
+    log.error("Authentication Error: {}", e.getMessage());
+
     return ResponseEntity
         .status(ErrorCode.UNAUTHORIZED.getStatus())
         .body(ErrorResponse.of(


### PR DESCRIPTION
## 연관된 이슈
Close #33 

## 작업 내역
- DB 연결부분 추가 (Config server 통해서 DB 연결 -> 추후 논의 필요)
- 공통 예외 처리를 위해 Handler, ErrorCode, ErrorResponse 부분 구현
- ExceptionConverter 을 구현해 Checked Exception에 대응할 수 있도록 구현

- ExceptionConverter 예시

`요청`
```java
{
    "name": "",           // @NotBlank 위반
    "email": "invalid",   // @Email 위반
    "password": "123"     // @Size 위반
}
```

`응답`
```java
{
    "status": 400,
    "message": "잘못된 입력값입니다",
    "path": "/api/users",
    "errors": [
        {
            "field": "name",
            "value": "",
            "reason": "이름은 필수입니다"
        },
        {
            "field": "email",
            "value": "invalid",
            "reason": "올바른 이메일 형식이어야 합니다"
        },
        {
            "field": "password",
            "value": "123",
            "reason": "비밀번호는 8자 이상이어야 합니다"
        }
    ]
}

```

## 테스트
- 예외 처리 동작 확인

## 문제 및 해결


## 다음 진행사항
- 알림 생성 카프카 연동

## 리뷰 요구사항
- 공통으로 추가 필요한 예외 처리 부분이 있을지 살펴봐주시면 감사하겠습니다 ! 