### PR TITLE
[Feat/statistics-read] 통계 목록 조회 API 개발

### DIFF
--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/dto/request/StatisticsCreateRequestDto.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/dto/request/StatisticsCreateRequestDto.java
@@ -1,0 +1,27 @@
+package com.trillionares.tryit.statistics.application.dto.request;
+
+import com.trillionares.tryit.statistics.presentation.dto.StatisticsCreateRequest;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record StatisticsCreateRequestDto(
+        UUID productId,
+        Integer highestScore,
+        Integer lowestScore,
+        Double averageScore,
+        Integer reviewCount,
+        Long durationTime) {
+
+    public static StatisticsCreateRequestDto from(StatisticsCreateRequest statisticsCreateRequest) {
+        return StatisticsCreateRequestDto.builder()
+                .productId(statisticsCreateRequest.getProductId())
+                .highestScore(statisticsCreateRequest.getHighestScore())
+                .lowestScore(statisticsCreateRequest.getLowestScore())
+                .reviewCount(statisticsCreateRequest.getReviewCount())
+                .durationTime(statisticsCreateRequest.getDurationTime())
+                .build();
+    }
+}

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/dto/request/StatisticsCreateRequestDto.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/dto/request/StatisticsCreateRequestDto.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record StatisticsCreateRequestDto(
+        UUID userId,
         UUID productId,
         Integer highestScore,
         Integer lowestScore,
@@ -17,6 +18,7 @@ public record StatisticsCreateRequestDto(
 
     public static StatisticsCreateRequestDto from(StatisticsCreateRequest statisticsCreateRequest) {
         return StatisticsCreateRequestDto.builder()
+                .userId(statisticsCreateRequest.getUserId())
                 .productId(statisticsCreateRequest.getProductId())
                 .highestScore(statisticsCreateRequest.getHighestScore())
                 .lowestScore(statisticsCreateRequest.getLowestScore())

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/dto/response/StatisticsCreateResponseDto.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/dto/response/StatisticsCreateResponseDto.java
@@ -1,0 +1,20 @@
+package com.trillionares.tryit.statistics.application.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record StatisticsCreateResponseDto(
+        UUID statisticsId,
+        LocalDateTime createdAt) {
+
+    public static StatisticsCreateResponseDto of(UUID statisticsId, LocalDateTime createdAt) {
+        return StatisticsCreateResponseDto.builder()
+                .statisticsId(statisticsId)
+                .createdAt(createdAt)
+                .build();
+    }
+}

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/dto/response/StatisticsGetResponseDto.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/dto/response/StatisticsGetResponseDto.java
@@ -1,0 +1,32 @@
+package com.trillionares.tryit.statistics.application.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record StatisticsGetResponseDto(
+        UUID statisticsId,
+        UUID userId,
+        UUID productId,
+        Integer highestScore,
+         Integer lowestScore,
+         Integer reviewCount,
+         Long durationTime,
+        LocalDateTime createdAt) {
+
+    public static StatisticsGetResponseDto of(UUID statisticsId, UUID userId, UUID productId, Integer highestScore, Integer lowestScore, Integer reviewCount, Long durationTime, LocalDateTime createdAt) {
+        return StatisticsGetResponseDto.builder()
+                .statisticsId(statisticsId)
+                .userId(userId)
+                .productId(productId)
+                .highestScore(highestScore)
+                .lowestScore(lowestScore)
+                .reviewCount(reviewCount)
+                .durationTime(durationTime)
+                .createdAt(createdAt)
+                .build();
+    }
+}

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/service/StatisticsService.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/service/StatisticsService.java
@@ -1,0 +1,23 @@
+package com.trillionares.tryit.statistics.application.service;
+
+import com.trillionares.tryit.statistics.application.dto.request.StatisticsCreateRequestDto;
+import com.trillionares.tryit.statistics.application.dto.response.StatisticsCreateResponseDto;
+import com.trillionares.tryit.statistics.domain.model.Statistics;
+import com.trillionares.tryit.statistics.domain.respository.StatisticsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StatisticsService {
+
+    private final StatisticsRepository statisticsRepository;
+
+    @Transactional
+    public StatisticsCreateResponseDto createStatistics(StatisticsCreateRequestDto statisticsCreateRequestDto) {
+        Statistics statistics =  statisticsRepository.save(Statistics.of(statisticsCreateRequestDto.productId(),statisticsCreateRequestDto.highestScore(),
+                statisticsCreateRequestDto.lowestScore(),statisticsCreateRequestDto.reviewCount(),statisticsCreateRequestDto.durationTime()));
+        return StatisticsCreateResponseDto.of(statistics.getStatisticsId(),statistics.getCreatedAt());
+    }
+}

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/service/StatisticsService.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/service/StatisticsService.java
@@ -2,11 +2,15 @@ package com.trillionares.tryit.statistics.application.service;
 
 import com.trillionares.tryit.statistics.application.dto.request.StatisticsCreateRequestDto;
 import com.trillionares.tryit.statistics.application.dto.response.StatisticsCreateResponseDto;
+import com.trillionares.tryit.statistics.application.dto.response.StatisticsGetResponseDto;
 import com.trillionares.tryit.statistics.domain.model.Statistics;
 import com.trillionares.tryit.statistics.domain.respository.StatisticsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -20,5 +24,12 @@ public class StatisticsService {
                 statisticsCreateRequestDto.productId(),statisticsCreateRequestDto.highestScore(),
                 statisticsCreateRequestDto.lowestScore(),statisticsCreateRequestDto.reviewCount(),statisticsCreateRequestDto.durationTime()));
         return StatisticsCreateResponseDto.of(statistics.getStatisticsId(),statistics.getCreatedAt());
+    }
+
+    public List<StatisticsGetResponseDto> getAllStatistics() {
+        return statisticsRepository.findAll().stream().map(statistics -> StatisticsGetResponseDto.of(
+                statistics.getStatisticsId(),statistics.getUserId(),statistics.getProductId(),
+                statistics.getHighestScore(),statistics.getLowestScore(), statistics.getReviewCount(),
+                        statistics.getDurationTime(),statistics.getCreatedAt())).collect(Collectors.toList());
     }
 }

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/service/StatisticsService.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/service/StatisticsService.java
@@ -16,7 +16,8 @@ public class StatisticsService {
 
     @Transactional
     public StatisticsCreateResponseDto createStatistics(StatisticsCreateRequestDto statisticsCreateRequestDto) {
-        Statistics statistics =  statisticsRepository.save(Statistics.of(statisticsCreateRequestDto.productId(),statisticsCreateRequestDto.highestScore(),
+        Statistics statistics =  statisticsRepository.save(Statistics.of(statisticsCreateRequestDto.userId(),
+                statisticsCreateRequestDto.productId(),statisticsCreateRequestDto.highestScore(),
                 statisticsCreateRequestDto.lowestScore(),statisticsCreateRequestDto.reviewCount(),statisticsCreateRequestDto.durationTime()));
         return StatisticsCreateResponseDto.of(statistics.getStatisticsId(),statistics.getCreatedAt());
     }

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/service/StatisticsService.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/service/StatisticsService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -30,6 +31,13 @@ public class StatisticsService {
         return statisticsRepository.findAll().stream().map(statistics -> StatisticsGetResponseDto.of(
                 statistics.getStatisticsId(),statistics.getUserId(),statistics.getProductId(),
                 statistics.getHighestScore(),statistics.getLowestScore(), statistics.getReviewCount(),
-                        statistics.getDurationTime(),statistics.getCreatedAt())).collect(Collectors.toList());
+                statistics.getDurationTime(),statistics.getCreatedAt())).collect(Collectors.toList());
+    }
+
+    public List<StatisticsGetResponseDto> getStatistics(UUID userId) {
+        return statisticsRepository.findAllByUserId(userId).stream().map(statistics -> StatisticsGetResponseDto.of(
+                statistics.getStatisticsId(),statistics.getUserId(),statistics.getProductId(),
+                statistics.getHighestScore(),statistics.getLowestScore(), statistics.getReviewCount(),
+                statistics.getDurationTime(),statistics.getCreatedAt())).collect(Collectors.toList());
     }
 }

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/common/base/BaseEntity.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/common/base/BaseEntity.java
@@ -3,6 +3,7 @@ package com.trillionares.tryit.statistics.domain.common.base;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -10,6 +11,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
@@ -36,6 +38,6 @@ public abstract class BaseEntity {
     @Column(name = "deleted_by")
     private String deletedBy;
 
-    @Column(name = "is_delete", nullable = false)
-    private boolean isDelete;
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted;
 }

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/model/Statistics.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/model/Statistics.java
@@ -19,6 +19,9 @@ public class Statistics extends BaseEntity {
     @Column(name = "statistics_id")
     private UUID statisticsId;
 
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
     @Column(name = "product_id", nullable = false)
     private UUID productId;
 
@@ -34,8 +37,9 @@ public class Statistics extends BaseEntity {
     @Column(name = "duration_time", nullable = false)
     private long durationTime;
 
-    public static Statistics of(UUID productId, int highestScore, int lowestScore, int reviewCount, long durationTime) {
+    public static Statistics of(UUID userId, UUID productId, int highestScore, int lowestScore, int reviewCount, long durationTime) {
         return Statistics.builder()
+                .userId(userId)
                 .productId(productId)
                 .highestScore(highestScore)
                 .lowestScore(lowestScore)

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/model/Statistics.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/model/Statistics.java
@@ -31,19 +31,15 @@ public class Statistics extends BaseEntity {
     @Column(name = "review_count", nullable = false)
     private int reviewCount;
 
-    @Column(name = "hot_keyword")
-    private String hotKeyword;
-
     @Column(name = "duration_time", nullable = false)
     private long durationTime;
 
-    public static Statistics of(UUID productId, int highestScore, int lowestScore, int reviewCount, String hotKeyword, long durationTime) {
+    public static Statistics of(UUID productId, int highestScore, int lowestScore, int reviewCount, long durationTime) {
         return Statistics.builder()
                 .productId(productId)
                 .highestScore(highestScore)
                 .lowestScore(lowestScore)
                 .reviewCount(reviewCount)
-                .hotKeyword(hotKeyword)
                 .durationTime(durationTime)
                 .build();
     }

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/respository/StatisticsRepository.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/respository/StatisticsRepository.java
@@ -3,8 +3,12 @@ package com.trillionares.tryit.statistics.domain.respository;
 import com.trillionares.tryit.statistics.domain.model.Statistics;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface StatisticsRepository {
 
     Statistics save(Statistics statistics);
+
+    List<Statistics> findAll();
 }

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/respository/StatisticsRepository.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/respository/StatisticsRepository.java
@@ -4,6 +4,7 @@ import com.trillionares.tryit.statistics.domain.model.Statistics;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.UUID;
 
 @Repository
 public interface StatisticsRepository {
@@ -11,4 +12,6 @@ public interface StatisticsRepository {
     Statistics save(Statistics statistics);
 
     List<Statistics> findAll();
+
+    List<Statistics> findAllByUserId(UUID userId);
 }

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/respository/StatisticsRepository.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/respository/StatisticsRepository.java
@@ -1,0 +1,10 @@
+package com.trillionares.tryit.statistics.domain.respository;
+
+import com.trillionares.tryit.statistics.domain.model.Statistics;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StatisticsRepository {
+
+    Statistics save(Statistics statistics);
+}

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/infrastructure/persistence/StatisticsRepositoryImpl.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/infrastructure/persistence/StatisticsRepositoryImpl.java
@@ -1,0 +1,10 @@
+package com.trillionares.tryit.statistics.infrastructure.persistence;
+
+import com.trillionares.tryit.statistics.domain.model.Statistics;
+import com.trillionares.tryit.statistics.domain.respository.StatisticsRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface StatisticsRepositoryImpl extends JpaRepository<Statistics, UUID>, StatisticsRepository {
+}

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/controller/StatisticsController.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/controller/StatisticsController.java
@@ -27,7 +27,7 @@ public class StatisticsController {
     }
 
     @GetMapping("/statistics")
-    public BaseResponse<List<StatisticsGetResponseDto>> getStatistics() {
+    public BaseResponse<List<StatisticsGetResponseDto>> getAllStatistics() {
         return BaseResponse.of(HttpStatus.OK.value(), HttpStatus.OK,"통계 전체 조회",statisticsService.getAllStatistics());
     }
 }

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/controller/StatisticsController.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/controller/StatisticsController.java
@@ -1,0 +1,24 @@
+package com.trillionares.tryit.statistics.presentation.controller;
+
+import com.trillionares.tryit.statistics.application.dto.request.StatisticsCreateRequestDto;
+import com.trillionares.tryit.statistics.application.dto.response.StatisticsCreateResponseDto;
+import com.trillionares.tryit.statistics.application.service.StatisticsService;
+import com.trillionares.tryit.statistics.presentation.dto.BaseResponse;
+import com.trillionares.tryit.statistics.presentation.dto.StatisticsCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class StatisticsController {
+
+    private final StatisticsService statisticsService;
+
+    @PostMapping("/statistics")
+    public BaseResponse<StatisticsCreateResponseDto> createReview(@RequestBody StatisticsCreateRequest statisticsCreateRequest) {
+        return BaseResponse.of(HttpStatus.CREATED.value(), HttpStatus.CREATED,"통계 생성 성공",statisticsService.createStatistics(StatisticsCreateRequestDto.from(statisticsCreateRequest)));
+    }
+}

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/controller/StatisticsController.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/controller/StatisticsController.java
@@ -8,12 +8,10 @@ import com.trillionares.tryit.statistics.presentation.dto.BaseResponse;
 import com.trillionares.tryit.statistics.presentation.dto.StatisticsCreateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,5 +27,10 @@ public class StatisticsController {
     @GetMapping("/statistics")
     public BaseResponse<List<StatisticsGetResponseDto>> getAllStatistics() {
         return BaseResponse.of(HttpStatus.OK.value(), HttpStatus.OK,"통계 전체 조회",statisticsService.getAllStatistics());
+    }
+
+    @GetMapping("/statistics/{userId}")
+    public BaseResponse<List<StatisticsGetResponseDto>> getStatistics(@PathVariable("userId") UUID userId) {
+        return BaseResponse.of(HttpStatus.OK.value(), HttpStatus.OK,"통계 목록 조회",statisticsService.getStatistics(userId));
     }
 }

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/controller/StatisticsController.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/controller/StatisticsController.java
@@ -2,14 +2,18 @@ package com.trillionares.tryit.statistics.presentation.controller;
 
 import com.trillionares.tryit.statistics.application.dto.request.StatisticsCreateRequestDto;
 import com.trillionares.tryit.statistics.application.dto.response.StatisticsCreateResponseDto;
+import com.trillionares.tryit.statistics.application.dto.response.StatisticsGetResponseDto;
 import com.trillionares.tryit.statistics.application.service.StatisticsService;
 import com.trillionares.tryit.statistics.presentation.dto.BaseResponse;
 import com.trillionares.tryit.statistics.presentation.dto.StatisticsCreateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,5 +24,10 @@ public class StatisticsController {
     @PostMapping("/statistics")
     public BaseResponse<StatisticsCreateResponseDto> createReview(@RequestBody StatisticsCreateRequest statisticsCreateRequest) {
         return BaseResponse.of(HttpStatus.CREATED.value(), HttpStatus.CREATED,"통계 생성 성공",statisticsService.createStatistics(StatisticsCreateRequestDto.from(statisticsCreateRequest)));
+    }
+
+    @GetMapping("/statistics")
+    public BaseResponse<List<StatisticsGetResponseDto>> getStatistics() {
+        return BaseResponse.of(HttpStatus.OK.value(), HttpStatus.OK,"통계 전체 조회",statisticsService.getAllStatistics());
     }
 }

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/dto/BaseResponse.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/dto/BaseResponse.java
@@ -1,0 +1,25 @@
+package com.trillionares.tryit.statistics.presentation.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class BaseResponse<T> {
+
+    private Integer status;
+    private HttpStatus code;
+    private String message;
+    private T data;
+
+    public static <T> BaseResponse of(Integer status, HttpStatus code, String message, T data) {
+        return BaseResponse.<T>builder()
+                .status(status)
+                .code(code)
+                .message(message)
+                .data(data)
+                .build();
+    }
+}

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/dto/StatisticsCreateRequest.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/dto/StatisticsCreateRequest.java
@@ -1,0 +1,15 @@
+package com.trillionares.tryit.statistics.presentation.dto;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class StatisticsCreateRequest {
+
+    private UUID productId;
+    private Integer highestScore;
+    private Integer lowestScore;
+    private Integer reviewCount;
+    private Long durationTime;
+}

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/dto/StatisticsCreateRequest.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/dto/StatisticsCreateRequest.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 @Getter
 public class StatisticsCreateRequest {
 
+    private UUID userId;
     private UUID productId;
     private Integer highestScore;
     private Integer lowestScore;


### PR DESCRIPTION
## 연관된 이슈
Close #68 

## 작업 내역
- 통계 목록 조회 API 구현
- 통계 목록 조회 API 수동 테스트

## 테스트
- [x] API 테스트

## 문제 및 해결
- 문제 : 동일 URL 대해 ReqeustParm 값으로 구분이 가능한 것으로 예상했으나, 통계 전체 조회와 통계 목록 조회 부분에서 문제 발생
- 해결 : 유저와 통계 식별자 구분이 어려울 것으로 예상되나, RequestParam -> PathVariable 형식으로 변경하여 해결, 추후 의논 필요

## 다음 진행사항
- 요청에 대한 값 검증 수행
- 테스트 코드 작성

## 리뷰 요구사항
