### PR TITLE
feat: 모집 가능 여부 검증 및 Kafka 통신 로직 구현

### DIFF
--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/RecruitmentEndpoint.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/RecruitmentEndpoint.java
@@ -1,8 +1,12 @@
 package com.trillionares.tryit.product.application.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trillionares.tryit.product.application.service.RecruitmentService;
+import com.trillionares.tryit.product.domain.common.json.JsonUtils;
 import com.trillionares.tryit.product.domain.repository.RecruitmentRepository;
+import com.trillionares.tryit.product.presentation.dto.common.kafka.SubmissionToRecruitmentRequestDto;
 import com.trillionares.tryit.product.presentation.dto.response.GetRecruitmentResponse;
+import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,10 +33,29 @@ public class RecruitmentEndpoint {
         return false;
     }
 
-    @KafkaListener(groupId = "inventoryManagement", topics = "minusProduct")
-    public void minusProduct(String message) {
-        log.info("minusProduct: {}", message);
+    @KafkaListener(topics = "checkPossible", groupId = "recruitment-tryit")
+    public void handleSubmissionRequest(String message) {
+        try {
+            SubmissionToRecruitmentRequestDto requestDto = JsonUtils.fromJson(message, SubmissionToRecruitmentRequestDto.class);
 
-        // TODO: 구매수량 넘겨주면, 재고에서 수량만큼 빼고, 현재 인원 늘려주기
+            // 모집 가능 여부 확인
+            boolean isPossible = recruitmentService.checkAndUpdateRecruitment(
+                    UUID.fromString(requestDto.recruitmentId()),
+                    requestDto.quantity()
+            );
+
+            // 결과 상태 결정
+            String status = isPossible ? "APPLIED" : "FAILED_CAPACITY";
+
+            // 결과 전송
+            recruitmentService.sendSubmissionResponse(
+                    requestDto.submissionId(),
+                    requestDto.recruitmentId(),
+                    requestDto.userId(),
+                    status
+            );
+        } catch (Exception e) {
+            log.error("Failed to process message from 'checkPossible'", e);
+        }
     }
 }

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/RecruitmentService.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/RecruitmentService.java
@@ -1,27 +1,34 @@
 package com.trillionares.tryit.product.application.service;
 
+import com.trillionares.tryit.product.domain.common.json.JsonUtils;
 import com.trillionares.tryit.product.domain.model.recruitment.Recruitment;
 import com.trillionares.tryit.product.domain.model.recruitment.type.RecruitmentStatus;
 import com.trillionares.tryit.product.domain.repository.RecruitmentRepository;
+import com.trillionares.tryit.product.presentation.dto.common.kafka.KafkaMessage;
+import com.trillionares.tryit.product.presentation.dto.common.kafka.RecruitmentSubmissionResponseDto;
 import com.trillionares.tryit.product.presentation.dto.request.CreateRecruitmentRequest;
 import com.trillionares.tryit.product.presentation.dto.request.UpdateRecruitmentRequest;
 import com.trillionares.tryit.product.presentation.dto.request.UpdateRecruitmentStatusRequest;
 import com.trillionares.tryit.product.presentation.dto.response.GetRecruitmentResponse;
 import com.trillionares.tryit.product.presentation.dto.response.RecruitmentIdResponse;
 import com.trillionares.tryit.product.presentation.dto.response.UpdateRecruitmentStatusResponse;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class RecruitmentService {
 
     private final RecruitmentRepository recruitmentRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
 
 
     @Transactional
@@ -91,5 +98,41 @@ public class RecruitmentService {
                 recruitment.getRecruitmentStatus());
     }
 
+
+    @Transactional
+    public boolean checkAndUpdateRecruitment(UUID recruitmentId, int quantity) {
+        Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
+                .orElseThrow(() -> new RuntimeException("Not Found Recruitment"));
+
+        // 모집 상태 확인
+        if (recruitment.getRecruitmentStatus() == RecruitmentStatus.ENDED ||
+                recruitment.getRecruitmentStatus() == RecruitmentStatus.PAUSED) {
+            return false;
+        }
+
+        // 모집 인원 초과 확인
+        if (recruitment.getCurrentParticipants() + quantity > recruitment.getMaxParticipants()) {
+            return false;
+        }
+
+        // 모집 정보 업데이트
+        recruitment.updateCurrentParticipants(recruitment.getCurrentParticipants() + quantity);
+        recruitmentRepository.save(recruitment);
+        return true;
+    }
+
+    public void sendSubmissionResponse(String submissionId, String recruitmentId, String userId, String status) {
+        try {
+            RecruitmentSubmissionResponseDto response = RecruitmentSubmissionResponseDto
+                    .of(submissionId, recruitmentId, userId, status);
+
+            String responseJson = JsonUtils.toJson(response);
+            KafkaMessage sendMessage = KafkaMessage.of(responseJson);
+            String sendMessageJson = JsonUtils.toJson(sendMessage);
+            kafkaTemplate.send("updateStatus", sendMessageJson);
+        } catch (Exception e) {
+            throw new RuntimeException("Submission 로 메시지 생성 실패");
+        }
+    }
 
 }

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/model/recruitment/Recruitment.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/model/recruitment/Recruitment.java
@@ -75,5 +75,8 @@ public class Recruitment {
         this.recruitmentStatus = status;
     }
 
+    public void updateCurrentParticipants(long currentParticipants) {
+        this.currentParticipants = currentParticipants;
+    }
 }
 

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/common/kafka/KafkaMessage.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/common/kafka/KafkaMessage.java
@@ -1,0 +1,15 @@
+package com.trillionares.tryit.product.presentation.dto.common.kafka;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record KafkaMessage(
+        UUID id,
+        String payload,
+        String timestamp
+
+) {
+    public static KafkaMessage of(String sendPayloadJson) {
+        return new KafkaMessage(UUID.randomUUID(), sendPayloadJson, String.valueOf(LocalDateTime.now()));
+    }
+}

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/common/kafka/RecruitmentSubmissionResponseDto.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/common/kafka/RecruitmentSubmissionResponseDto.java
@@ -1,0 +1,13 @@
+package com.trillionares.tryit.product.presentation.dto.common.kafka;
+
+public record RecruitmentSubmissionResponseDto(
+        String submissionId,
+        String recruitmentId,
+        String userId,
+        String status
+) {
+    public static RecruitmentSubmissionResponseDto of(String submissionId, String recruitmentId, String userId,
+                                                      String status) {
+        return new RecruitmentSubmissionResponseDto(submissionId, recruitmentId, userId, status);
+    }
+}

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/common/kafka/SubmissionToRecruitmentRequestDto.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/common/kafka/SubmissionToRecruitmentRequestDto.java
@@ -1,0 +1,12 @@
+package com.trillionares.tryit.product.presentation.dto.common.kafka;
+
+public record SubmissionToRecruitmentRequestDto (
+         String submissionId,
+         String recruitmentId,
+         String userId,
+         int quantity,
+         String submissionTime,
+         String messageId,
+         String eventTimestamp
+) {
+}


### PR DESCRIPTION
## 연관된 이슈
Close #109

## 작업 내역
- 모집 엔티티에 현재 참가자 수 업데이트 기능 추가
- KafkaMessage 클래스 추가
- Kafka 관련 DTO 클래스 추가 (`SubmissionToRecruitmentRequestDto`, `RecruitmentSubmissionResponseDto`)
- 모집 가능 여부 확인 및 결과 처리 기능 추가

## 테스트
- [x] API 테스트 
- [ ] 테스트 코드 작성

## 다음 진행사항
- Kafka 메시지 전송과 관련된 예외 상황 테스트 추가
- `SubmissionToRecruitmentRequestDto` 및 `RecruitmentSubmissionResponseDto`의 추가 필드 요구사항 검토 및 확장

## 리뷰 요구사항
- 현재 작업한 KafkaMessage와 관련된 DTO 클래스들의 설계가 적합한지 검토해주세요.
- 모집 상태와 관련된 검증 로직이 적절히 동작하는지 확인 부탁드립니다.