### PR TITLE
[Feat/submission-authorization] feat: 체험단 신청 CRUD 권한 검증 및 recruitment kafka 컨벤션 수정

### DIFF
--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/CategoryService.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/CategoryService.java
@@ -20,12 +20,10 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
 
     @Transactional
-    public CategoryIdResponseDto createCategory(CategoryInfoRequestDto requestDto) {
-        // TODO: 권한 체크 (관리자)
-
-        // TODO: UserId 토큰에서 받아오기
-        UUID userId = UUID.randomUUID();
-        String username = "나 관리자";
+    public CategoryIdResponseDto createCategory(String username, String role, CategoryInfoRequestDto requestDto) {
+        if(!validatePermission(role)){
+            throw new IllegalArgumentException("권한이 없는 사용자입니다.");
+        }
 
         Optional<Category> category = categoryRepository.findByCategoryNameAndIsDeleteFalse(requestDto.getCategoryName());
         if (category.isPresent()) {
@@ -37,5 +35,12 @@ public class CategoryService {
 
         CategoryIdResponseDto responseDto = CategoryIdResponseDto.from(newCategory.getCategoryId());
         return responseDto;
+    }
+
+    private Boolean validatePermission(String role) {
+        if(role.contains("ADMIN")){
+            return true;
+        }
+        return false;
     }
 }

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/ProductService.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/ProductService.java
@@ -208,8 +208,7 @@ public class ProductService {
 
         List<ProductInfoResponseDto> responseDto = new ArrayList<>();
         for (Product product : productList) {
-            // TODO: User Service 호출해서 userId -> Seller 정보 받아오기
-            String seller = "나판매";
+            String seller = authClient.getUserInfo(product.getUserId()).getData().getUsername();
 
             if(product.getProductCategory().getCategory().getCategoryName() == null) {
                 throw new CategoryNotFoundException(CategoryMessage.NOT_FOUND_CATEGORY.getMessage());
@@ -251,8 +250,7 @@ public class ProductService {
             throw new ProductNotFoundException(ProductMessage.NOT_FOUND_PRODUCT.getMessage());
         }
 
-        // TODO: User Service 호출해서 Seller 정보 받아오기
-        String seller = "나판매";
+        String seller = authClient.getUserInfo(product.getUserId()).getData().getUsername();
 
         // TODO: 카테고리 정보 여러개면 문자열 붙이기
         if(product.getProductCategory().getCategory().getCategoryName() == null) {

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/ProductService.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/ProductService.java
@@ -284,9 +284,7 @@ public class ProductService {
             throw new ProductNotFoundException(ProductMessage.NOT_FOUND_PRODUCT.getMessage());
         }
 
-        // TODO: 내가 등록한 물건인지 확인
-        log.info("product.getUserId(): {}, userId: {}", product.getUserId(), userId);
-        if(!isProductOwner(userId, product.getUserId())) {
+        if(!isProductOwner(userId, product.getUserId()) && role.contains("COMPANY")) {
             throw new IllegalArgumentException("판매자가 등록한 상품이 아닙니다.");
         }
 

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/RecruitmentEndpoint.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/RecruitmentEndpoint.java
@@ -1,12 +1,9 @@
 package com.trillionares.tryit.product.application.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.trillionares.tryit.product.application.service.RecruitmentService;
 import com.trillionares.tryit.product.domain.common.json.JsonUtils;
-import com.trillionares.tryit.product.domain.repository.RecruitmentRepository;
+import com.trillionares.tryit.product.presentation.dto.common.kafka.KafkaMessage;
 import com.trillionares.tryit.product.presentation.dto.common.kafka.SubmissionToRecruitmentRequestDto;
 import com.trillionares.tryit.product.presentation.dto.response.GetRecruitmentResponse;
-import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,7 +33,8 @@ public class RecruitmentEndpoint {
     @KafkaListener(topics = "checkPossible", groupId = "recruitment-tryit")
     public void handleSubmissionRequest(String message) {
         try {
-            SubmissionToRecruitmentRequestDto requestDto = JsonUtils.fromJson(message, SubmissionToRecruitmentRequestDto.class);
+            KafkaMessage kafkaMessage = JsonUtils.fromJson(message, KafkaMessage.class);
+            SubmissionToRecruitmentRequestDto requestDto = JsonUtils.fromJson(kafkaMessage.payload(), SubmissionToRecruitmentRequestDto.class);
 
             // 모집 가능 여부 확인
             boolean isPossible = recruitmentService.checkAndUpdateRecruitment(

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/RecruitmentService.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/RecruitmentService.java
@@ -4,6 +4,7 @@ import com.trillionares.tryit.product.domain.common.json.JsonUtils;
 import com.trillionares.tryit.product.domain.model.recruitment.Recruitment;
 import com.trillionares.tryit.product.domain.model.recruitment.type.RecruitmentStatus;
 import com.trillionares.tryit.product.domain.repository.RecruitmentRepository;
+import com.trillionares.tryit.product.presentation.dto.RecruitmentExistAndStatusDto;
 import com.trillionares.tryit.product.presentation.dto.common.kafka.KafkaMessage;
 import com.trillionares.tryit.product.presentation.dto.common.kafka.RecruitmentSubmissionResponseDto;
 import com.trillionares.tryit.product.presentation.dto.request.CreateRecruitmentRequest;
@@ -12,6 +13,7 @@ import com.trillionares.tryit.product.presentation.dto.request.UpdateRecruitment
 import com.trillionares.tryit.product.presentation.dto.response.GetRecruitmentResponse;
 import com.trillionares.tryit.product.presentation.dto.response.RecruitmentIdResponse;
 import com.trillionares.tryit.product.presentation.dto.response.UpdateRecruitmentStatusResponse;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -135,4 +137,27 @@ public class RecruitmentService {
         }
     }
 
+    public RecruitmentExistAndStatusDto isExistRecruitmentById(UUID recruitmentId) {
+        Optional<Recruitment> recruitment = recruitmentRepository.existsByIdAndIsDeletedFalse(recruitmentId);
+
+        if(!recruitment.isPresent() || recruitment.isEmpty() || recruitment == null) {
+            return RecruitmentExistAndStatusDto.of(false, "NOT_FOUND");
+        }
+
+        // TODO: RecruitmentStatus 수정을 임의로 할 수 없다고 생각해서 매핑만 시켜둠
+        switch (recruitment.get().getRecruitmentStatus()) {
+            case WAITING:
+                return RecruitmentExistAndStatusDto.of(true, "WAITING");
+            case STARTED:
+                return RecruitmentExistAndStatusDto.of(true, "STARTED");
+            case RESTARTED:
+                return RecruitmentExistAndStatusDto.of(true, "RESTARTED");
+            case PAUSED:
+                return RecruitmentExistAndStatusDto.of(true, "PAUSED");
+            case ENDED:
+                return RecruitmentExistAndStatusDto.of(true, "ENDED");
+            default:
+                return RecruitmentExistAndStatusDto.of(false, "NOT_FOUND");
+        }
+    }
 }

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/RecruitmentService.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/RecruitmentService.java
@@ -138,7 +138,7 @@ public class RecruitmentService {
     }
 
     public RecruitmentExistAndStatusDto isExistRecruitmentById(UUID recruitmentId) {
-        Optional<Recruitment> recruitment = recruitmentRepository.existsByIdAndIsDeletedFalse(recruitmentId);
+        Optional<Recruitment> recruitment = recruitmentRepository.findByRecruitmentId(recruitmentId);
 
         if(!recruitment.isPresent() || recruitment.isEmpty() || recruitment == null) {
             return RecruitmentExistAndStatusDto.of(false, "NOT_FOUND");

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/client/AuthClient.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/client/AuthClient.java
@@ -2,7 +2,9 @@ package com.trillionares.tryit.product.domain.client;
 
 import com.trillionares.tryit.product.infrastructure.config.FeignConfig;
 import com.trillionares.tryit.product.presentation.dto.InfoByUsernameResponseDto;
+import com.trillionares.tryit.product.presentation.dto.UserResponseDto;
 import com.trillionares.tryit.product.presentation.dto.common.base.BaseResponseDto;
+import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,4 +14,7 @@ public interface AuthClient {
 
     @GetMapping("/users/internals/username/{username}")
     BaseResponseDto<InfoByUsernameResponseDto> getUserByUsername(@PathVariable("username") String username);
+
+    @GetMapping("/internals/{userId}")
+    BaseResponseDto<UserResponseDto> getUserInfo(UUID userId);
 }

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/client/AuthClient.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/client/AuthClient.java
@@ -1,0 +1,15 @@
+package com.trillionares.tryit.product.domain.client;
+
+import com.trillionares.tryit.product.infrastructure.config.FeignConfig;
+import com.trillionares.tryit.product.presentation.dto.InfoByUsernameResponseDto;
+import com.trillionares.tryit.product.presentation.dto.common.base.BaseResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name="auth-service", configuration = FeignConfig.class)
+public interface AuthClient {
+
+    @GetMapping("/users/internals/username/{username}")
+    BaseResponseDto<InfoByUsernameResponseDto> getUserByUsername(@PathVariable("username") String username);
+}

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/repository/RecruitmentRepository.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/repository/RecruitmentRepository.java
@@ -6,5 +6,5 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecruitmentRepository extends JpaRepository<Recruitment, UUID>, CustomRecruitmentRepository{
-    Optional<Recruitment> existsByIdAndIsDeletedFalse(UUID recruitmentId);
+    Optional<Recruitment> findByRecruitmentId(UUID recruitmentId);
 }

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/repository/RecruitmentRepository.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/repository/RecruitmentRepository.java
@@ -1,8 +1,10 @@
 package com.trillionares.tryit.product.domain.repository;
 
 import com.trillionares.tryit.product.domain.model.recruitment.Recruitment;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecruitmentRepository extends JpaRepository<Recruitment, UUID>, CustomRecruitmentRepository{
+    Optional<Recruitment> existsByIdAndIsDeletedFalse(UUID recruitmentId);
 }

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/CategoryController.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/CategoryController.java
@@ -7,6 +7,7 @@ import com.trillionares.tryit.product.presentation.dto.request.CategoryInfoReque
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,9 +19,13 @@ public class CategoryController {
     private final CategoryService categoryService;
 
     @PostMapping()
-    public BaseResponseDto<CategoryIdResponseDto> createCategory(@RequestBody CategoryInfoRequestDto requestDto) {
+    public BaseResponseDto<CategoryIdResponseDto> createCategory(
+            @RequestHeader("X-Auth-Username") String username,
+            @RequestHeader("X-Auth-Role") String role,
+            @RequestBody CategoryInfoRequestDto requestDto
+    ) {
         try {
-            CategoryIdResponseDto responseDto = categoryService.createCategory(requestDto);
+            CategoryIdResponseDto responseDto = categoryService.createCategory(username, role, requestDto);
 
             return BaseResponseDto.from(200, null, "카테고리 등록 성공", responseDto);
         } catch (Exception e) {

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/ProductController.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/ProductController.java
@@ -128,19 +128,23 @@ public class ProductController {
 
     @PutMapping("/{productId}")
     public BaseResponseDto<ProductIdResponseDto> updateProduct(
+            @RequestHeader("X-Auth-Username") String username,
+            @RequestHeader("X-Auth-Role") String role,
             @PathVariable("productId") UUID productId,
             @RequestPart("productInfoRequestDto") String requestDto,
             @RequestPart(value = "productMainImage") MultipartFile productMainImage
     ) {
         try {
             ProductInfoRequestDto productInfoRequestDto = JsonUtils.fromJson(requestDto, ProductInfoRequestDto.class);
-            ProductIdResponseDto responseDto = productService.updateProduct(productId, productInfoRequestDto, productMainImage);
+            ProductIdResponseDto responseDto = productService.updateProduct(username, role, productId, productInfoRequestDto, productMainImage);
 
             return BaseResponseDto.from(HttpStatus.NO_CONTENT.value(), HttpStatus.NO_CONTENT, ProductMessage.MODIFIED_PRODUCT_SUCCESS.getMessage(), responseDto);
         } catch (CategoryNotFoundException cnfe) {
             return BaseResponseDto.from(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND, cnfe.getMessage(), null);
         } catch (ProductNotFoundException pnfe) {
             return BaseResponseDto.from(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND, pnfe.getMessage(), null);
+        } catch (IllegalArgumentException ie) {
+            return BaseResponseDto.from(HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST, ie.getMessage(), null);
         } catch (RuntimeException re) {
             return BaseResponseDto.from(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR, ProductMessage.NOT_DEFINED_SERVER_RUNTIME_ERROR.getMessage(), null);
         } catch (Exception e) {

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/ProductController.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/ProductController.java
@@ -1,13 +1,13 @@
 package com.trillionares.tryit.product.presentation.controller;
 
 import com.querydsl.core.types.Predicate;
+import com.trillionares.tryit.product.application.service.ProductService;
 import com.trillionares.tryit.product.domain.common.json.JsonUtils;
 import com.trillionares.tryit.product.domain.common.message.ProductMessage;
 import com.trillionares.tryit.product.domain.model.product.Product;
-import com.trillionares.tryit.product.application.service.ProductService;
 import com.trillionares.tryit.product.presentation.dto.common.base.BaseResponseDto;
-import com.trillionares.tryit.product.presentation.dto.response.ProductIdResponseDto;
 import com.trillionares.tryit.product.presentation.dto.request.ProductInfoRequestDto;
+import com.trillionares.tryit.product.presentation.dto.response.ProductIdResponseDto;
 import com.trillionares.tryit.product.presentation.dto.response.ProductInfoResponseDto;
 import com.trillionares.tryit.product.presentation.exception.CategoryNotFoundException;
 import com.trillionares.tryit.product.presentation.exception.ProductMainImageNotFoundException;
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -44,12 +44,14 @@ public class ProductController {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BaseResponseDto<ProductIdResponseDto> createProduct(
+            @RequestHeader("X-Auth-Username") String username,
+            @RequestHeader("X-Auth-Role") String role,
             @RequestPart("productInfoRequestDto") String requestDto,
             @RequestPart(value = "productMainImage") MultipartFile productMainImage
     ) {
         try {
             ProductInfoRequestDto productInfoRequestDto = JsonUtils.fromJson(requestDto, ProductInfoRequestDto.class);
-            ProductIdResponseDto responseDto = productService.createProduct(productInfoRequestDto, productMainImage);
+            ProductIdResponseDto responseDto = productService.createProduct(username, role, productInfoRequestDto, productMainImage);
 
             return BaseResponseDto.from(HttpStatus.CREATED.value(), HttpStatus.CREATED, ProductMessage.CREATED_PRODUCT_SUCCESS.getMessage(), responseDto);
         } catch (CategoryNotFoundException cnfe) {
@@ -63,12 +65,14 @@ public class ProductController {
 
     @PostMapping(value = "/kafka", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BaseResponseDto<ProductIdResponseDto> createProductUsingKafka(
+            @RequestHeader("X-Auth-Username") String username,
+            @RequestHeader("X-Auth-Role") String role,
             @RequestPart("productInfoRequestDto") String requestDto,
             @RequestPart(value = "productMainImage") MultipartFile productMainImage
     ) {
         try {
             ProductInfoRequestDto productInfoRequestDto = JsonUtils.fromJson(requestDto, ProductInfoRequestDto.class);
-            ProductIdResponseDto responseDto = productService.createProductUsingkafka(productInfoRequestDto, productMainImage);
+            ProductIdResponseDto responseDto = productService.createProductUsingkafka(username, role, productInfoRequestDto, productMainImage);
 
             return BaseResponseDto.from(HttpStatus.CREATED.value(), HttpStatus.CREATED, ProductMessage.CREATED_PRODUCT_SUCCESS.getMessage(), responseDto);
         } catch (CategoryNotFoundException cnfe) {

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/ProductController.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/ProductController.java
@@ -153,9 +153,13 @@ public class ProductController {
     }
 
     @DeleteMapping("/{productId}")
-    public BaseResponseDto<ProductIdResponseDto> deleteProduct(@PathVariable("productId") UUID productId) {
+    public BaseResponseDto<ProductIdResponseDto> deleteProduct(
+            @RequestHeader("X-Auth-Username") String username,
+            @RequestHeader("X-Auth-Role") String role,
+            @PathVariable("productId") UUID productId
+    ) {
         try {
-            ProductIdResponseDto responseDto = productService.deleteProduct(productId);
+            ProductIdResponseDto responseDto = productService.deleteProduct(username, role, productId);
 
             return BaseResponseDto.from(HttpStatus.NO_CONTENT.value(), HttpStatus.NO_CONTENT, ProductMessage.DELETED_PRODUCT_SUCCESS.getMessage(), responseDto);
         } catch (ProductNotFoundException pnfe) {

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/RecruitmentController.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/RecruitmentController.java
@@ -1,6 +1,8 @@
 package com.trillionares.tryit.product.presentation.controller;
 
 import com.trillionares.tryit.product.application.service.RecruitmentService;
+import com.trillionares.tryit.product.presentation.dto.RecruitmentExistAndStatusDto;
+import com.trillionares.tryit.product.presentation.dto.common.base.BaseResponseDto;
 import com.trillionares.tryit.product.presentation.dto.request.CreateRecruitmentRequest;
 import com.trillionares.tryit.product.presentation.dto.request.UpdateRecruitmentRequest;
 import com.trillionares.tryit.product.presentation.dto.request.UpdateRecruitmentStatusRequest;
@@ -14,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -77,5 +80,10 @@ public class RecruitmentController {
                 recruitmentService.updateRecruitmentStatus(recruitmentId, request));
     }
 
+    @GetMapping("/isExist/{recruitmentId}")
+    public BaseResponseDto<RecruitmentExistAndStatusDto> isExistRecruitmentById(@PathVariable("recruitmentId") UUID recruitmentId) {
+        RecruitmentExistAndStatusDto responseDto = recruitmentService.isExistRecruitmentById(recruitmentId);
 
+        return BaseResponseDto.from(HttpStatus.OK.value(), HttpStatus.OK, "OK", responseDto);
+    }
 }

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/InfoByUsernameResponseDto.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/InfoByUsernameResponseDto.java
@@ -1,0 +1,16 @@
+package com.trillionares.tryit.product.presentation.dto;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class InfoByUsernameResponseDto {
+    private UUID userId;
+    private String username;
+    private String role;
+    private String slackId;
+}

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/RecruitmentExistAndStatusDto.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/RecruitmentExistAndStatusDto.java
@@ -1,0 +1,22 @@
+package com.trillionares.tryit.product.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitmentExistAndStatusDto {
+    private Boolean isExist;
+    private String status;
+
+    public static RecruitmentExistAndStatusDto of(Boolean isExist, String recruitmentStatus) {
+        return RecruitmentExistAndStatusDto.builder()
+                .isExist(isExist)
+                .status(recruitmentStatus)
+                .build();
+    }
+}

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/UserResponseDto.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/UserResponseDto.java
@@ -1,0 +1,19 @@
+package com.trillionares.tryit.product.presentation.dto;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserResponseDto {
+    private UUID userId;
+    private String username;
+    private String fullname;
+    private String email;
+    private String phoneNumber;
+    private String slackId;
+    private String role;
+}

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/common/kafka/SubmissionToRecruitmentRequestDto.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/common/kafka/SubmissionToRecruitmentRequestDto.java
@@ -5,8 +5,6 @@ public record SubmissionToRecruitmentRequestDto (
          String recruitmentId,
          String userId,
          int quantity,
-         String submissionTime,
-         String messageId,
-         String eventTimestamp
+         String submissionTime
 ) {
 }

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/TrialApplication.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/TrialApplication.java
@@ -2,8 +2,10 @@ package com.trillionares.tryit.trial;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class TrialApplication {
 
 	public static void main(String[] args) {

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/client/AuthClient.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/client/AuthClient.java
@@ -1,0 +1,20 @@
+package com.trillionares.tryit.trial.jhtest.domain.client;
+
+import com.trillionares.tryit.trial.jhtest.infrastructure.config.FeignConfig;
+import com.trillionares.tryit.trial.jhtest.presentation.dto.InfoByUsernameResponseDto;
+import com.trillionares.tryit.trial.jhtest.presentation.dto.UserResponseDto;
+import com.trillionares.tryit.trial.jhtest.presentation.dto.common.base.BaseResponseDto;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name="auth-service", configuration = FeignConfig.class)
+public interface AuthClient {
+
+    @GetMapping("/users/internals/username/{username}")
+    BaseResponseDto<InfoByUsernameResponseDto> getUserByUsername(@PathVariable("username") String username);
+
+    @GetMapping("/internals/{userId}")
+    BaseResponseDto<UserResponseDto> getUserInfo(UUID userId);
+}

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/client/RecruitmentClient.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/client/RecruitmentClient.java
@@ -11,6 +11,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 @FeignClient(name="product-service", configuration = FeignConfig.class)
 public interface RecruitmentClient {
 
-    @GetMapping("/isExist/{recruitmentId}")
+    @GetMapping("/recruitments/isExist/{recruitmentId}")
     BaseResponseDto<RecruitmentExistAndStatusDto> isExistRecruitmentById(@PathVariable("recruitmentId") UUID recruitmentId);
 }

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/client/RecruitmentClient.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/client/RecruitmentClient.java
@@ -1,0 +1,16 @@
+package com.trillionares.tryit.trial.jhtest.domain.client;
+
+import com.trillionares.tryit.trial.jhtest.infrastructure.config.FeignConfig;
+import com.trillionares.tryit.trial.jhtest.presentation.dto.RecruitmentExistAndStatusDto;
+import com.trillionares.tryit.trial.jhtest.presentation.dto.common.base.BaseResponseDto;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name="product-service", configuration = FeignConfig.class)
+public interface RecruitmentClient {
+
+    @GetMapping("/isExist/{recruitmentId}")
+    BaseResponseDto<RecruitmentExistAndStatusDto> isExistRecruitmentById(@PathVariable("recruitmentId") UUID recruitmentId);
+}

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/repository/TrialRepository.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/repository/TrialRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface TrialRepository extends JpaRepository<Trial, UUID> {
 
     Optional<Trial> findBySubmissionIdAndIsDeletedFalse(UUID submissionId);
+
+    boolean existsByUserIdAndRecruitmentIdAndIsDeletedFalse(UUID userId, UUID recruitmentId);
 }

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/service/TrialService.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/service/TrialService.java
@@ -147,9 +147,8 @@ public class TrialService {
             throw new IllegalArgumentException("관리자나 판매자는 체험 신청할 수 없습니다.");
         }
 
-        // TODO: UserId토큰에서 받아오기
-        UUID userId = UUID.randomUUID();
-        String username = "신청자";
+        // TODO: UserId 비동기 업데이트 고려해보기
+        UUID userId = authClient.getUserByUsername(username).getData().getUserId();
 
         Trial trial = trialRepository.findBySubmissionIdAndIsDeletedFalse(submissionId).orElse(null);
         if(trial == null){

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/service/TrialService.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/service/TrialService.java
@@ -1,10 +1,12 @@
 package com.trillionares.tryit.trial.jhtest.domain.service;
 
 import com.trillionares.tryit.trial.jhtest.domain.client.AuthClient;
+import com.trillionares.tryit.trial.jhtest.domain.client.RecruitmentClient;
 import com.trillionares.tryit.trial.jhtest.domain.common.json.JsonUtils;
 import com.trillionares.tryit.trial.jhtest.domain.model.Trial;
 import com.trillionares.tryit.trial.jhtest.domain.model.type.SubmissionStatus;
 import com.trillionares.tryit.trial.jhtest.domain.repository.TrialRepository;
+import com.trillionares.tryit.trial.jhtest.presentation.dto.RecruitmentExistAndStatusDto;
 import com.trillionares.tryit.trial.jhtest.presentation.dto.SendNotificationDto;
 import com.trillionares.tryit.trial.jhtest.presentation.dto.SendRecruitmentDto;
 import com.trillionares.tryit.trial.jhtest.presentation.dto.SubmissionIdAndStatusResponseDto;
@@ -28,6 +30,8 @@ public class TrialService {
     private final TrialRepository trialRepository;
 
     private final AuthClient authClient;
+    private final RecruitmentClient recruitmentClient;
+
     private final KafkaTemplate<String, String> kafkaTemplate;
 
     @Transactional
@@ -36,11 +40,8 @@ public class TrialService {
             throw new IllegalArgumentException("관리자나 판매자는 체험 신청할 수 없습니다.");
         }
 
-        // TODO: UserId토큰에서 받아오기
-        UUID userId = UUID.randomUUID();
-        String username = "신청자";
-        
-        // TODO: 이전 신청내역없는지 검증
+        checkExistRecruitment(requestDto.getRecruitmentId());
+
         // TODO: UserId 비동기 업데이트 고려해보기
         UUID userId = authClient.getUserByUsername(username).getData().getUserId();
 
@@ -126,13 +127,6 @@ public class TrialService {
         } catch (Exception e) {
             throw new RuntimeException("Notification으로 메시지 생성 실패");
         }
-    }
-
-    private Boolean checkExistRecruitment(UUID recruitmentId) {
-        kafkaTemplate.send("recruitmentExistenceCheck",
-                "recruitmentId", String.valueOf(recruitmentId));
-
-        return true;
     }
 
     public TrialInfoResponseDto getTrialById(UUID submissionId) {

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/service/TrialService.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/service/TrialService.java
@@ -46,7 +46,7 @@ public class TrialService {
         UUID userId = authClient.getUserByUsername(username).getData().getUserId();
 
         if(existPastSubmissionHistory(userId, requestDto.getRecruitmentId())) {
-            throw new RuntimeException("이전 신청내역이 있는 모집 입니다.");
+            throw new IllegalArgumentException("이전 신청내역이 있는 모집 입니다.");
         }
 
         Trial trial = TrialInfoRequestDto.toCreateEntity(requestDto, userId, username);
@@ -78,13 +78,13 @@ public class TrialService {
 
         if(!responseDto.getIsExist()) {
             throw new IllegalArgumentException("존재하지 않는 모집 입니다.");
-        } else if(!responseDto.getStatus().contains("WAITING")) {
+        } else if(responseDto.getStatus().contains("WAITING")) {
             throw new IllegalArgumentException("모집이 시작되지 않았습니다.");
-        } else if(!responseDto.getStatus().contains("PAUSED")) {
+        } else if(responseDto.getStatus().contains("PAUSED")) {
             throw new IllegalArgumentException("모집이 중단 되었습니다.");
-        } else if(!responseDto.getStatus().contains("ENDED")) {
+        } else if(responseDto.getStatus().contains("ENDED")) {
             throw new IllegalArgumentException("모집이 종료 되었습니다.");
-        } else if(!responseDto.getStatus().contains("NOT_FOUND")) {
+        } else if(responseDto.getStatus().contains("NOT_FOUND")) {
             throw new IllegalArgumentException("모집을 찾을 수 없습니다.");
         }
     }

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/service/TrialService.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/service/TrialService.java
@@ -44,11 +44,9 @@ public class TrialService {
         // TODO: UserId 비동기 업데이트 고려해보기
         UUID userId = authClient.getUserByUsername(username).getData().getUserId();
 
-        // TODO: recruitmentID 존재하는지 검증
-//        if(!checkExistRecruitment(requestDto.getRecruitmentId())) {
-//            log.error("해당 모집이 없습니다.");
-//            throw new RuntimeException("해당 모집이 없습니다.");
-//        }
+        if(existPastSubmissionHistory(userId, requestDto.getRecruitmentId())) {
+            throw new RuntimeException("이전 신청내역이 있는 모집 입니다.");
+        }
 
         Trial trial = TrialInfoRequestDto.toCreateEntity(requestDto, userId, username);
 

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/service/TrialService.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/domain/service/TrialService.java
@@ -1,5 +1,6 @@
 package com.trillionares.tryit.trial.jhtest.domain.service;
 
+import com.trillionares.tryit.trial.jhtest.domain.client.AuthClient;
 import com.trillionares.tryit.trial.jhtest.domain.common.json.JsonUtils;
 import com.trillionares.tryit.trial.jhtest.domain.model.Trial;
 import com.trillionares.tryit.trial.jhtest.domain.model.type.SubmissionStatus;
@@ -25,6 +26,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class TrialService {
 
     private final TrialRepository trialRepository;
+
+    private final AuthClient authClient;
     private final KafkaTemplate<String, String> kafkaTemplate;
 
     @Transactional
@@ -38,6 +41,8 @@ public class TrialService {
         String username = "신청자";
         
         // TODO: 이전 신청내역없는지 검증
+        // TODO: UserId 비동기 업데이트 고려해보기
+        UUID userId = authClient.getUserByUsername(username).getData().getUserId();
 
         // TODO: recruitmentID 존재하는지 검증
 //        if(!checkExistRecruitment(requestDto.getRecruitmentId())) {

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/infrastructure/config/FeignConfig.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/infrastructure/config/FeignConfig.java
@@ -1,0 +1,18 @@
+package com.trillionares.tryit.trial.jhtest.infrastructure.config;
+
+import feign.codec.Encoder;
+import feign.form.spring.SpringFormEncoder;
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
+import org.springframework.cloud.openfeign.support.SpringEncoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignConfig {
+
+    @Bean
+    public Encoder feignFormEncoder(ObjectFactory<HttpMessageConverters> messageConverters) {
+        return new SpringFormEncoder(new SpringEncoder(messageConverters));
+    }
+}

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/controller/trialController.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/controller/trialController.java
@@ -61,11 +61,13 @@ public class trialController {
 
     @PatchMapping("/{submissionId}")
     public BaseResponseDto<TrialIdResponseDto> changeStatusOfTrial(
+            @RequestHeader("X-Auth-Username") String username,
+            @RequestHeader("X-Auth-Role") String role,
             @PathVariable("submissionId") UUID submissionId,
             @RequestParam("status") SubmissionStatus status
     ) {
         try {
-            TrialIdResponseDto responseDto = trialService.changeStatusOfTrial(submissionId, status);
+            TrialIdResponseDto responseDto = trialService.changeStatusOfTrial(username, role, submissionId, status);
 
             return BaseResponseDto.from(HttpStatus.OK.value(), HttpStatus.OK, "신청을 변경했습니다. 신청 상태 : " + status, responseDto);
 

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/controller/trialController.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/controller/trialController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,10 +31,12 @@ public class trialController {
 
     @PostMapping()
     public BaseResponseDto<TrialIdResponseDto> createTrial(
+            @RequestHeader("X-Auth-Username") String username,
+            @RequestHeader("X-Auth-Role") String role,
             @RequestBody TrialInfoRequestDto requestDto
     ) {
         try{
-            TrialIdResponseDto responseDto = trialService.createTrial(requestDto);
+            TrialIdResponseDto responseDto = trialService.createTrial(username, role, requestDto);
 
             return BaseResponseDto.from(HttpStatus.CREATED.value(), HttpStatus.CREATED, "신청을 완료했습니다.", responseDto);
         } catch (RuntimeException re) {

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/controller/trialController.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/controller/trialController.java
@@ -46,11 +46,13 @@ public class trialController {
 
     @GetMapping("/{submissionId}")
     public BaseResponseDto<TrialInfoResponseDto> getTrialById(
+            @RequestHeader("X-Auth-Username") String username,
+            @RequestHeader("X-Auth-Role") String role,
             @PathVariable("submissionId") UUID submissionId
     ) {
         try {
 
-            TrialInfoResponseDto responseDto = trialService.getTrialById(submissionId);
+            TrialInfoResponseDto responseDto = trialService.getTrialById(username, role, submissionId);
 
             return BaseResponseDto.from(HttpStatus.OK.value(), HttpStatus.OK, "신청을 조회했습니다.", responseDto);
 

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/controller/trialController.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/controller/trialController.java
@@ -39,6 +39,8 @@ public class trialController {
             TrialIdResponseDto responseDto = trialService.createTrial(username, role, requestDto);
 
             return BaseResponseDto.from(HttpStatus.CREATED.value(), HttpStatus.CREATED, "신청을 완료했습니다.", responseDto);
+        } catch (IllegalArgumentException ie) {
+          return BaseResponseDto.from(HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST, ie.getMessage(), null);
         } catch (RuntimeException re) {
             return BaseResponseDto.from(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR, "실행 중 오류", null);
         }

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/controller/trialController.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/controller/trialController.java
@@ -78,10 +78,12 @@ public class trialController {
 
     @DeleteMapping("/{submissionId}")
     public BaseResponseDto<TrialIdResponseDto> deleteTrial(
+            @RequestHeader("X-Auth-Username") String username,
+            @RequestHeader("X-Auth-Role") String role,
             @PathVariable("submissionId") UUID submissionId
     ) {
         try {
-            TrialIdResponseDto responseDto = trialService.deleteTrial(submissionId);
+            TrialIdResponseDto responseDto = trialService.deleteTrial(username, role, submissionId);
 
             return BaseResponseDto.from(HttpStatus.OK.value(), HttpStatus.OK, "신청을 취소했습니다.", responseDto);
 

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/dto/InfoByUsernameResponseDto.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/dto/InfoByUsernameResponseDto.java
@@ -1,0 +1,16 @@
+package com.trillionares.tryit.trial.jhtest.presentation.dto;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class InfoByUsernameResponseDto {
+    private UUID userId;
+    private String username;
+    private String role;
+    private String slackId;
+}

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/dto/RecruitmentExistAndStatusDto.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/dto/RecruitmentExistAndStatusDto.java
@@ -1,0 +1,13 @@
+package com.trillionares.tryit.trial.jhtest.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitmentExistAndStatusDto {
+    private Boolean isExist;
+    private String status;
+}

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/dto/UpdateStatusDto.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/dto/UpdateStatusDto.java
@@ -10,5 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UpdateStatusDto {
     private UUID submissionId;
+    private UUID recruitmentId;
+    private UUID userId;
     private String status;
 }

--- a/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/dto/UserResponseDto.java
+++ b/com.trillionares.tryit.trial/src/main/java/com/trillionares/tryit/trial/jhtest/presentation/dto/UserResponseDto.java
@@ -1,0 +1,19 @@
+package com.trillionares.tryit.trial.jhtest.presentation.dto;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserResponseDto {
+    private UUID userId;
+    private String username;
+    private String fullname;
+    private String email;
+    private String phoneNumber;
+    private String slackId;
+    private String role;
+}


### PR DESCRIPTION
## 연관된 이슈
Close #124

## 작업 내역
- 체험단 신청 CRUD 권한 검증 로직 추가
- AuthClient 추가 (동기 통신)
- 모집 존재 여부 확인 위한 RecruitmentClient 추가 (동기 통신)
  - RecruitmentController API 추가 (모집 존재 여부 확인용)
- FeignClient를 위한 DTO 추가
- recruitment kafka listener (topics: checkPossible) 메세지 수신 오류 해결

## 테스트
- [x] API 테스트 
- [ ] 테스트 코드 작성

## 문제 및 해결
(작업 중 발생한 문제와 그 해결 방법에 대해 간단히 설명해주세요.)

## 다음 진행사항

## 리뷰 요구사항

@Namgyu11 kafka listener쪽에서 메시지를 Json으로 변환할때, 잘 못 변환되어서 수정했습니다.