### PR TITLE
feat: 모집 소유권 검증 및 사용자 권한 처리 로직 추가

### DIFF
--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/RecruitmentService.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/RecruitmentService.java
@@ -1,5 +1,6 @@
 package com.trillionares.tryit.product.application.service;
 
+import com.trillionares.tryit.product.domain.client.AuthClient;
 import com.trillionares.tryit.product.domain.common.json.JsonUtils;
 import com.trillionares.tryit.product.domain.model.recruitment.Recruitment;
 import com.trillionares.tryit.product.domain.model.recruitment.type.RecruitmentStatus;
@@ -31,11 +32,16 @@ public class RecruitmentService {
 
     private final RecruitmentRepository recruitmentRepository;
     private final KafkaTemplate<String, String> kafkaTemplate;
+    private final AuthClient authClient;
 
 
     @Transactional
-    public RecruitmentIdResponse createRecruitment(CreateRecruitmentRequest request) {
+    public RecruitmentIdResponse createRecruitment(CreateRecruitmentRequest request, String username, String role) {
+        UUID userId = authClient.getUserByUsername(username).getData().getUserId();
+        validatePermission(role);
+
         Recruitment recruitment = Recruitment.builder()
+                .userId(userId)
                 .productId(request.productId())
                 .recruitmentTitle(request.title())
                 .recruitmentDescription(request.description())
@@ -53,9 +59,14 @@ public class RecruitmentService {
 
     @Transactional
     public RecruitmentIdResponse updateRecruitment(UUID recruitmentId,
-                                                   UpdateRecruitmentRequest request) {
+                                                   UpdateRecruitmentRequest request, String username, String role) {
+        UUID userId = authClient.getUserByUsername(username).getData().getUserId();
+        validatePermission(role);
+
         Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
-                .orElseThrow(() -> new RuntimeException(""));
+                .orElseThrow(() -> new RuntimeException("Not Found Recruitment"));
+
+        validateOwnership(recruitmentId, userId);
 
         recruitment.updateRecruitment(request.title(), request.description(), request.startTime(),
                 request.during(), request.endTime(), request.maxParticipants());
@@ -66,10 +77,14 @@ public class RecruitmentService {
     }
 
     @Transactional
-    public RecruitmentIdResponse deleteRecruitment(UUID recruitmentId) {
-        Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
-                .orElseThrow(() -> new RuntimeException(""));
+    public RecruitmentIdResponse deleteRecruitment(UUID recruitmentId, String username, String role) {
+        UUID userId = authClient.getUserByUsername(username).getData().getUserId();
+        validatePermission(role);
 
+        Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
+                .orElseThrow(() -> new RuntimeException("Not Found Recruitment"));
+
+        validateOwnership(recruitmentId, userId);
         // BaseEntity 구현 후 soft delete 로 변경
         recruitmentRepository.delete(recruitment);
 
@@ -87,11 +102,18 @@ public class RecruitmentService {
         return recruitmentRepository.getRecruitmentList(pageable);
     }
 
+    @Transactional
     public UpdateRecruitmentStatusResponse updateRecruitmentStatus(UUID recruitmentId,
-                                                                   UpdateRecruitmentStatusRequest request) {
-        Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
-                .orElseThrow(() -> new RuntimeException(""));
+                                                                   UpdateRecruitmentStatusRequest request,
+                                                                   String username,
+                                                                   String role) {
+        UUID userId = authClient.getUserByUsername(username).getData().getUserId();
+        validatePermission(role);
 
+        Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
+                .orElseThrow(() -> new RuntimeException("Not Found Recruitment"));
+
+        validateOwnership(recruitmentId, userId);
         recruitment.updateStatus(request.status());
 
         recruitmentRepository.save(recruitment);
@@ -140,7 +162,7 @@ public class RecruitmentService {
     public RecruitmentExistAndStatusDto isExistRecruitmentById(UUID recruitmentId) {
         Optional<Recruitment> recruitment = recruitmentRepository.findByRecruitmentId(recruitmentId);
 
-        if(!recruitment.isPresent() || recruitment.isEmpty() || recruitment == null) {
+        if (!recruitment.isPresent() || recruitment.isEmpty() || recruitment == null) {
             return RecruitmentExistAndStatusDto.of(false, "NOT_FOUND");
         }
 
@@ -160,4 +182,19 @@ public class RecruitmentService {
                 return RecruitmentExistAndStatusDto.of(false, "NOT_FOUND");
         }
     }
+
+    private void validatePermission(String role) {
+        if (!(role.contains("ADMIN") || role.contains("COMPANY"))) {
+            throw new RuntimeException("권한이 없습니다.");
+        }
+    }
+
+    private void validateOwnership(UUID recruitmentId, UUID userId) {
+        UUID ownerId = recruitmentRepository.findOwnerIdByRecruitmentId(recruitmentId)
+                .orElseThrow(() -> new RuntimeException("Recruitment not found."));
+        if (!ownerId.equals(userId)) {
+            throw new RuntimeException("권한이 없습니다.");
+        }
+    }
+
 }

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/model/recruitment/Recruitment.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/model/recruitment/Recruitment.java
@@ -1,5 +1,6 @@
 package com.trillionares.tryit.product.domain.model.recruitment;
 
+import com.trillionares.tryit.product.domain.common.base.BaseEntity;
 import com.trillionares.tryit.product.domain.model.recruitment.type.RecruitmentStatus;
 import jakarta.persistence.*;
 import lombok.*;
@@ -13,9 +14,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Recruitment {
-    //TODO: BaseEntity 상속
-
+public class Recruitment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "recruitment_id")

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/model/recruitment/Recruitment.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/model/recruitment/Recruitment.java
@@ -21,6 +21,9 @@ public class Recruitment {
     @Column(name = "recruitment_id")
     private UUID recruitmentId;
 
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
     @Column(name = "product_id", nullable = false)
     private UUID productId;
 

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/repository/RecruitmentRepository.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/repository/RecruitmentRepository.java
@@ -4,7 +4,13 @@ import com.trillionares.tryit.product.domain.model.recruitment.Recruitment;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface RecruitmentRepository extends JpaRepository<Recruitment, UUID>, CustomRecruitmentRepository{
+public interface RecruitmentRepository extends JpaRepository<Recruitment, UUID>, CustomRecruitmentRepository {
     Optional<Recruitment> findByRecruitmentId(UUID recruitmentId);
+
+    @Query("SELECT r.userId FROM Recruitment r WHERE r.recruitmentId = :recruitmentId")
+    Optional<UUID> findOwnerIdByRecruitmentId(@Param("recruitmentId") UUID recruitmentId);
+
 }

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/RecruitmentController.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/RecruitmentController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -36,25 +37,31 @@ public class RecruitmentController {
 
     @PostMapping
     public ResponseEntity<RecruitmentIdResponse> createRecruitment(
-            @Valid @RequestBody CreateRecruitmentRequest request
+            @Valid @RequestBody CreateRecruitmentRequest request,
+            @RequestHeader("X-Auth-Username") String username,
+            @RequestHeader("X-Auth-Role") String role
     ) {
-        return ResponseEntity.status(201).body(recruitmentService.createRecruitment(request));
+        return ResponseEntity.status(201).body(recruitmentService.createRecruitment(request, username, role));
     }
 
     @PatchMapping("{recruitmentId}")
     public ResponseEntity<RecruitmentIdResponse> updateRecruitment(
             @PathVariable UUID recruitmentId,
-            @Valid @RequestBody UpdateRecruitmentRequest request
+            @Valid @RequestBody UpdateRecruitmentRequest request,
+            @RequestHeader("X-Auth-Username") String username,
+            @RequestHeader("X-Auth-Role") String role
     ) {
-        return ResponseEntity.ok(recruitmentService.updateRecruitment(recruitmentId, request));
+        return ResponseEntity.ok(recruitmentService.updateRecruitment(recruitmentId, request, username, role));
     }
 
 
     @DeleteMapping("{recruitmentId}")
     public ResponseEntity<RecruitmentIdResponse> deleteRecruitment(
-            @PathVariable UUID recruitmentId
+            @PathVariable UUID recruitmentId,
+            @RequestHeader("X-Auth-Username") String username,
+            @RequestHeader("X-Auth-Role") String role
     ) {
-        return ResponseEntity.ok(recruitmentService.deleteRecruitment(recruitmentId));
+        return ResponseEntity.ok(recruitmentService.deleteRecruitment(recruitmentId, username, role));
     }
 
 
@@ -74,14 +81,17 @@ public class RecruitmentController {
     @PatchMapping("{recruitmentId}/status")
     public ResponseEntity<UpdateRecruitmentStatusResponse> updateRecruitmentStatus(
             @PathVariable UUID recruitmentId,
-            @RequestBody UpdateRecruitmentStatusRequest request
+            @RequestBody UpdateRecruitmentStatusRequest request,
+            @RequestHeader("X-Auth-Username") String username,
+            @RequestHeader("X-Auth-Role") String role
     ) {
         return ResponseEntity.ok(
-                recruitmentService.updateRecruitmentStatus(recruitmentId, request));
+                recruitmentService.updateRecruitmentStatus(recruitmentId, request, username, role));
     }
 
     @GetMapping("/isExist/{recruitmentId}")
-    public BaseResponseDto<RecruitmentExistAndStatusDto> isExistRecruitmentById(@PathVariable("recruitmentId") UUID recruitmentId) {
+    public BaseResponseDto<RecruitmentExistAndStatusDto> isExistRecruitmentById(
+            @PathVariable("recruitmentId") UUID recruitmentId) {
         RecruitmentExistAndStatusDto responseDto = recruitmentService.isExistRecruitmentById(recruitmentId);
 
         return BaseResponseDto.from(HttpStatus.OK.value(), HttpStatus.OK, "OK", responseDto);


### PR DESCRIPTION
## 연관된 이슈
Close #127 

## 작업 내역
- **`userId` 필드 추가**: `Recruitment` 엔티티에 `userId` 필드를 추가하여 모집 작성자를 명확히 구분.
- **소유권 검증 메서드 추가**: `validateOwnership` 메서드를 통해 요청자가 모집 작성자인지 확인.
- **사용자 권한 검증 로직 추가**: `validatePermission` 메서드를 통해 ADMIN 및 COMPANY 권한 검증.
- **CRUD 로직 수정**: `create`, `update`, `delete`, `updateStatus` 메서드에 소유권 및 권한 검증 로직 통합.
- **JPQL 기반 소유권 확인**: `RecruitmentRepository`에 `findOwnerIdByRecruitmentId` 메서드 추가로 1차 캐시 문제 방지.

## 테스트
- [x] API 테스트: 모집 생성, 수정, 삭제, 상태 업데이트 시 소유권 검증 테스트.

## 다음 진행사항
- 예외 메시지 및 에러 핸들링 표준화 작업.
- 사용자 권한 및 소유권 검증 관련 로직의 테스트 커버리지 확대.
