### PR TITLE
[Feat/review-role-validation] 리뷰 서비스 유저 권한 검증 추가

### DIFF
--- a/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/application/dto/response/ReviewGetUserByUsernameResponseDto.java
+++ b/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/application/dto/response/ReviewGetUserByUsernameResponseDto.java
@@ -1,0 +1,14 @@
+package com.trillionares.tryit.review.application.dto.response;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class ReviewGetUserByUsernameResponseDto {
+
+    private UUID userId;
+    private String username;
+    private String role;
+    private String slackId;
+}

--- a/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/application/service/ReviewService.java
+++ b/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/application/service/ReviewService.java
@@ -6,6 +6,7 @@ import com.trillionares.tryit.review.application.dto.response.*;
 import com.trillionares.tryit.review.domain.client.TrialClient;
 import com.trillionares.tryit.review.domain.model.Review;
 import com.trillionares.tryit.review.domain.repository.ReviewRepository;
+import com.trillionares.tryit.review.domain.service.ReviewValidation;
 import com.trillionares.tryit.review.libs.exception.ErrorCode;
 import com.trillionares.tryit.review.libs.exception.GlobalException;
 import com.trillionares.tryit.review.presentation.dto.BaseResponse;
@@ -22,14 +23,16 @@ import static com.trillionares.tryit.review.libs.exception.ErrorCode.REVIEW_CREA
 public class ReviewService {
 
     private final ReviewRepository reviewRepository;
+    private final ReviewValidation reviewValidation;
     private final TrialClient trialClient;
 
     @Transactional
-    public ReviewCreateResponseDto createReview(ReviewCreateRequestDto reviewCreateRequestDto) {
+    public ReviewCreateResponseDto createReview(ReviewCreateRequestDto reviewCreateRequestDto, String role) {
+
         BaseResponse<ReviewIsSelectedResponseDto> reviewIsSelectedResponseDto
                 = trialClient.isSelectedStatusOfTrial(reviewCreateRequestDto.submissionId());
 
-        if(!reviewIsSelectedResponseDto.getData().getIsSelected())
+        if(reviewValidation.isNotCreateValidation(role,reviewIsSelectedResponseDto.getData().getIsSelected()))
             throw new GlobalException(REVIEW_CREATE_FORBIDDEN);
 
         Review review = reviewRepository.save(Review.of(reviewCreateRequestDto.userId(),reviewCreateRequestDto.productId(),reviewCreateRequestDto.reviewTitle(),reviewCreateRequestDto.reviewContent(),reviewCreateRequestDto.reviewScore(),"image_url"));

--- a/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/application/service/ReviewService.java
+++ b/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/application/service/ReviewService.java
@@ -66,7 +66,17 @@ public class ReviewService {
     }
 
     @Transactional
-    public ReviewDeleteResponseDto deleteReview(UUID reviewId) {
+    public ReviewDeleteResponseDto deleteReview(UUID reviewId, String role, String username) {
+
+        BaseResponse<ReviewGetUserByUsernameResponseDto> reviewGetUserByUsernameResponseDto
+                = authClient.getUserByUsernameOfUser(username);
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.REVIEW_ID_NOT_FOUND));
+
+        if(reviewValidation.isNotDeleteValidation(role,review.getUserId(),reviewGetUserByUsernameResponseDto.getData().getUserId()))
+            throw new GlobalException(ErrorCode.REVIEW_DELETE_FORBIDDEN);
+
         reviewRepository.deleteById(reviewId);
         return ReviewDeleteResponseDto.from(reviewId);
     }

--- a/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/domain/client/AuthClient.java
+++ b/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/domain/client/AuthClient.java
@@ -1,0 +1,14 @@
+package com.trillionares.tryit.review.domain.client;
+
+import com.trillionares.tryit.review.application.dto.response.ReviewGetUserByUsernameResponseDto;
+import com.trillionares.tryit.review.presentation.dto.BaseResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name="auth-service")
+public interface AuthClient {
+
+    @GetMapping("/users/internals/username/{username}")
+    BaseResponse<ReviewGetUserByUsernameResponseDto> getUserByUsernameOfUser(@PathVariable("username") String username);
+}

--- a/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/domain/service/ReviewValidation.java
+++ b/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/domain/service/ReviewValidation.java
@@ -15,8 +15,8 @@ public class ReviewValidation {
         return "ROLE_MEMBER".equals(role);
     }
 
-    private boolean isSameAuthorAndModifier(UUID author, UUID modifier) {
-        return author.equals(modifier);
+    private boolean isSameAuthorAndActor(UUID author, UUID actor) {
+        return author.equals(actor);
     }
 
     public boolean isNotCreateValidation(String role, Boolean isSelected) {
@@ -24,10 +24,10 @@ public class ReviewValidation {
     }
 
     public boolean isNotUpdateValidation(String role, UUID author, UUID modifier) {
-        return !(isAdmin(role) || isSameAuthorAndModifier(author,modifier));
+        return !(isAdmin(role) || isSameAuthorAndActor(author,modifier));
     }
 
     public boolean isNotDeleteValidation(String role, UUID author, UUID deleter) {
-        return !(isAdmin(role) || isSameAuthorAndModifier(author,deleter));
+        return !(isAdmin(role) || isSameAuthorAndActor(author,deleter));
     }
 }

--- a/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/domain/service/ReviewValidation.java
+++ b/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/domain/service/ReviewValidation.java
@@ -26,4 +26,8 @@ public class ReviewValidation {
     public boolean isNotUpdateValidation(String role, UUID author, UUID modifier) {
         return !(isAdmin(role) || isSameAuthorAndModifier(author,modifier));
     }
+
+    public boolean isNotDeleteValidation(String role, UUID author, UUID modifier) {
+        return !(isAdmin(role) || isSameAuthorAndModifier(author,modifier));
+    }
 }

--- a/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/domain/service/ReviewValidation.java
+++ b/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/domain/service/ReviewValidation.java
@@ -2,6 +2,8 @@ package com.trillionares.tryit.review.domain.service;
 
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 @Service
 public class ReviewValidation {
 
@@ -13,7 +15,15 @@ public class ReviewValidation {
         return "ROLE_MEMBER".equals(role);
     }
 
+    private boolean isSameAuthorAndModifier(UUID author, UUID modifier) {
+        return author.equals(modifier);
+    }
+
     public boolean isNotCreateValidation(String role, Boolean isSelected) {
         return !((isAdmin(role) || isMember(role)) && isSelected);
+    }
+
+    public boolean isNotUpdateValidation(String role, UUID author, UUID modifier) {
+        return !(isAdmin(role) || isSameAuthorAndModifier(author,modifier));
     }
 }

--- a/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/domain/service/ReviewValidation.java
+++ b/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/domain/service/ReviewValidation.java
@@ -1,0 +1,15 @@
+package com.trillionares.tryit.review.domain.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReviewValidation {
+
+    private boolean isAdmin(String role) {
+        return "ROLE_ADMIN".equals(role);
+    }
+
+    private boolean isMember(String role) {
+        return "ROLE_MEMBER".equals(role);
+    }
+}

--- a/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/domain/service/ReviewValidation.java
+++ b/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/domain/service/ReviewValidation.java
@@ -12,4 +12,8 @@ public class ReviewValidation {
     private boolean isMember(String role) {
         return "ROLE_MEMBER".equals(role);
     }
+
+    public boolean isNotCreateValidation(String role, Boolean isSelected) {
+        return !((isAdmin(role) || isMember(role)) && isSelected);
+    }
 }

--- a/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/domain/service/ReviewValidation.java
+++ b/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/domain/service/ReviewValidation.java
@@ -27,7 +27,7 @@ public class ReviewValidation {
         return !(isAdmin(role) || isSameAuthorAndModifier(author,modifier));
     }
 
-    public boolean isNotDeleteValidation(String role, UUID author, UUID modifier) {
-        return !(isAdmin(role) || isSameAuthorAndModifier(author,modifier));
+    public boolean isNotDeleteValidation(String role, UUID author, UUID deleter) {
+        return !(isAdmin(role) || isSameAuthorAndModifier(author,deleter));
     }
 }

--- a/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/libs/exception/ErrorCode.java
+++ b/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/libs/exception/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode {
 
     // Review
     REVIEW_ID_NOT_FOUND(404, "리뷰를 찾을 수 없습니다."),
-    REVIEW_CREATE_FORBIDDEN(403, "리뷰 작성 권한이 없습니다.");
+    REVIEW_CREATE_FORBIDDEN(403, "리뷰 작성 권한이 없습니다."),
+    REVIEW_UPDATE_FORBIDDEN(403,"리뷰 수정 권한이 없습니다.");
 
     private final int status;
     private final String message;

--- a/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/libs/exception/ErrorCode.java
+++ b/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/libs/exception/ErrorCode.java
@@ -28,7 +28,8 @@ public enum ErrorCode {
     // Review
     REVIEW_ID_NOT_FOUND(404, "리뷰를 찾을 수 없습니다."),
     REVIEW_CREATE_FORBIDDEN(403, "리뷰 작성 권한이 없습니다."),
-    REVIEW_UPDATE_FORBIDDEN(403,"리뷰 수정 권한이 없습니다.");
+    REVIEW_UPDATE_FORBIDDEN(403,"리뷰 수정 권한이 없습니다."),
+    REVIEW_DELETE_FORBIDDEN(403,"리뷰 삭제 권한이 없습니다.");
 
     private final int status;
     private final String message;

--- a/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/presentation/controller/ReviewController.java
+++ b/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/presentation/controller/ReviewController.java
@@ -38,8 +38,11 @@ public class ReviewController {
 
     @PutMapping("/reviews/{reviewId}")
     public BaseResponse<ReviewUpdateResponseDto> updateReview(
+            @RequestHeader("X-Auth-Role") String role,
+            @RequestHeader("X-Auth-Username") String username,
             @RequestBody @Valid ReviewUpdateRequest reviewUpdateRequest, @PathVariable UUID reviewId) {
-        return BaseResponse.of(HttpStatus.OK.value(), HttpStatus.OK,"리뷰 수정 성공",reviewService.updateReview(ReviewUpdateRequestDto.from(reviewUpdateRequest),reviewId));
+        return BaseResponse.of(HttpStatus.OK.value(), HttpStatus.OK,"리뷰 수정 성공",
+                reviewService.updateReview(ReviewUpdateRequestDto.from(reviewUpdateRequest),reviewId,role,username));
     }
 
     @DeleteMapping("/reviews/{reviewId}")

--- a/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/presentation/controller/ReviewController.java
+++ b/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/presentation/controller/ReviewController.java
@@ -46,7 +46,10 @@ public class ReviewController {
     }
 
     @DeleteMapping("/reviews/{reviewId}")
-    public BaseResponse<ReviewDeleteResponseDto> deleteReview(@PathVariable UUID reviewId) {
-        return BaseResponse.of(HttpStatus.OK.value(), HttpStatus.OK,"리뷰 삭제 성공",reviewService.deleteReview(reviewId));
+    public BaseResponse<ReviewDeleteResponseDto> deleteReview(
+            @RequestHeader("X-Auth-Role") String role,
+            @RequestHeader("X-Auth-Username") String username,
+            @PathVariable UUID reviewId) {
+        return BaseResponse.of(HttpStatus.OK.value(), HttpStatus.OK,"리뷰 삭제 성공",reviewService.deleteReview(reviewId,role,username));
     }
 }

--- a/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/presentation/controller/ReviewController.java
+++ b/com.trillionares.tryit.review/src/main/java/com/trillionares/tryit/review/presentation/controller/ReviewController.java
@@ -24,9 +24,11 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @PostMapping("/reviews")
-    public BaseResponse<ReviewCreateResponseDto> createReview(@RequestBody @Valid ReviewCreateRequest reviewCreateRequest) {
+    public BaseResponse<ReviewCreateResponseDto> createReview(
+            @RequestHeader("X-Auth-Role") String role,
+            @RequestBody @Valid ReviewCreateRequest reviewCreateRequest) {
         return BaseResponse.of(HttpStatus.CREATED.value(),HttpStatus.CREATED,"리뷰 생성 성공",
-                reviewService.createReview(ReviewCreateRequestDto.from(reviewCreateRequest)));
+                reviewService.createReview(ReviewCreateRequestDto.from(reviewCreateRequest),role));
     }
 
     @GetMapping("/reviews/{reviewId}")


### PR DESCRIPTION
## 연관된 이슈
Close #126 

## 작업 내역
- 리뷰 검증 도메인 서비스 생성
- 리뷰 생성 권한 검증
- 리뷰 수정 권한 검증
- 리뷰 삭제 권한 검증

## 테스트
- [x] API 테스트

## 문제 및 해결
- 문제 1 : 각 권한에 대한 분기 로직 처리 필요
- 문제 2 : 수정, 삭제 처리 과정에서 작성자와 행위자 검증 필요 
- 문제 3 : 문제 1, 2 코드 추가로 인해 서비스의 역할이 커지게 됨
- 해결 : 권한 및 검증에 대한 책임을 리뷰 검증 도메인 서비스에 할당

## 다음 진행사항

## 리뷰 요구사항
