### PR TITLE
[Feat/statistics-role-validation] 통계 서비스 유저 권한 검증 추가

### DIFF
--- a/com.trillionares.tryit.statistics/build.gradle
+++ b/com.trillionares.tryit.statistics/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 
 	// validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// openfeign
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 dependencyManagement {

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/StatisticsApplication.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/StatisticsApplication.java
@@ -2,10 +2,12 @@ package com.trillionares.tryit.statistics;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 
 @EnableJpaAuditing
+@EnableFeignClients
 @SpringBootApplication
 public class StatisticsApplication {
 

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/dto/response/StatisticsGetUserByUsernameResponseDto.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/dto/response/StatisticsGetUserByUsernameResponseDto.java
@@ -1,0 +1,14 @@
+package com.trillionares.tryit.statistics.application.dto.response;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class StatisticsGetUserByUsernameResponseDto {
+
+    private UUID userId;
+    private String username;
+    private String role;
+    private String slackId;
+}

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/service/StatisticsService.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/service/StatisticsService.java
@@ -5,6 +5,9 @@ import com.trillionares.tryit.statistics.application.dto.response.StatisticsCrea
 import com.trillionares.tryit.statistics.application.dto.response.StatisticsGetResponseDto;
 import com.trillionares.tryit.statistics.domain.model.Statistics;
 import com.trillionares.tryit.statistics.domain.respository.StatisticsRepository;
+import com.trillionares.tryit.statistics.domain.service.StatisticsValidation;
+import com.trillionares.tryit.statistics.libs.exception.ErrorCode;
+import com.trillionares.tryit.statistics.libs.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +21,7 @@ import java.util.stream.Collectors;
 public class StatisticsService {
 
     private final StatisticsRepository statisticsRepository;
+    private final StatisticsValidation statisticsValidation;
 
     @Transactional
     public StatisticsCreateResponseDto createStatistics(StatisticsCreateRequestDto statisticsCreateRequestDto) {
@@ -27,7 +31,11 @@ public class StatisticsService {
         return StatisticsCreateResponseDto.of(statistics.getStatisticsId(),statistics.getCreatedAt());
     }
 
-    public List<StatisticsGetResponseDto> getAllStatistics() {
+    public List<StatisticsGetResponseDto> getAllStatistics(String role) {
+
+        if(statisticsValidation.isNotGetAllValidation(role))
+            throw new GlobalException(ErrorCode.STATISTICS_GET_ALL_FORBIDDEN);
+
         return statisticsRepository.findAll().stream().map(statistics -> StatisticsGetResponseDto.of(
                 statistics.getStatisticsId(),statistics.getUserId(),statistics.getProductId(),
                 statistics.getHighestScore(),statistics.getLowestScore(), statistics.getReviewCount(),

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/service/StatisticsService.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/application/service/StatisticsService.java
@@ -3,11 +3,14 @@ package com.trillionares.tryit.statistics.application.service;
 import com.trillionares.tryit.statistics.application.dto.request.StatisticsCreateRequestDto;
 import com.trillionares.tryit.statistics.application.dto.response.StatisticsCreateResponseDto;
 import com.trillionares.tryit.statistics.application.dto.response.StatisticsGetResponseDto;
+import com.trillionares.tryit.statistics.application.dto.response.StatisticsGetUserByUsernameResponseDto;
+import com.trillionares.tryit.statistics.domain.client.AuthClient;
 import com.trillionares.tryit.statistics.domain.model.Statistics;
 import com.trillionares.tryit.statistics.domain.respository.StatisticsRepository;
 import com.trillionares.tryit.statistics.domain.service.StatisticsValidation;
 import com.trillionares.tryit.statistics.libs.exception.ErrorCode;
 import com.trillionares.tryit.statistics.libs.exception.GlobalException;
+import com.trillionares.tryit.statistics.presentation.dto.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +25,7 @@ public class StatisticsService {
 
     private final StatisticsRepository statisticsRepository;
     private final StatisticsValidation statisticsValidation;
+    private final AuthClient authClient;
 
     @Transactional
     public StatisticsCreateResponseDto createStatistics(StatisticsCreateRequestDto statisticsCreateRequestDto) {
@@ -42,7 +46,14 @@ public class StatisticsService {
                 statistics.getDurationTime(),statistics.getCreatedAt())).collect(Collectors.toList());
     }
 
-    public List<StatisticsGetResponseDto> getStatistics(UUID userId) {
+    public List<StatisticsGetResponseDto> getStatistics(UUID userId, String role, String username) {
+
+        BaseResponse<StatisticsGetUserByUsernameResponseDto> statisticsGetUserByUsernameResponseDto
+                = authClient.getUserByUsernameOfUser(username);
+
+        if(statisticsValidation.isNotGetValidation(role,userId,statisticsGetUserByUsernameResponseDto.getData().getUserId()))
+            throw new GlobalException(ErrorCode.STATISTICS_GET_FORBIDDEN);
+
         return statisticsRepository.findAllByUserId(userId).stream().map(statistics -> StatisticsGetResponseDto.of(
                 statistics.getStatisticsId(),statistics.getUserId(),statistics.getProductId(),
                 statistics.getHighestScore(),statistics.getLowestScore(), statistics.getReviewCount(),

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/client/AuthClient.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/client/AuthClient.java
@@ -1,0 +1,14 @@
+package com.trillionares.tryit.statistics.domain.client;
+
+import com.trillionares.tryit.statistics.application.dto.response.StatisticsGetUserByUsernameResponseDto;
+import com.trillionares.tryit.statistics.presentation.dto.BaseResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name="auth-service")
+public interface AuthClient {
+
+    @GetMapping("/users/internals/username/{username}")
+    BaseResponse<StatisticsGetUserByUsernameResponseDto> getUserByUsernameOfUser(@PathVariable("username") String username);
+}

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/service/StatisticsValidation.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/service/StatisticsValidation.java
@@ -24,11 +24,6 @@ public class StatisticsValidation {
     }
 
     public boolean isNotGetValidation(String role, UUID company, UUID actor) {
-        System.out.println("role : "+role);
-        System.out.println("company : "+company);
-        System.out.println("actor : "+actor);
-        System.out.println((isCompany(role) && isSameCompanyAndActor(company,actor)));
-        System.out.println(!(isAdmin(role) || (isCompany(role) && isSameCompanyAndActor(company,actor))));
         return !(isAdmin(role) || (isCompany(role) && isSameCompanyAndActor(company,actor)));
     }
 }

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/service/StatisticsValidation.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/service/StatisticsValidation.java
@@ -2,6 +2,8 @@ package com.trillionares.tryit.statistics.domain.service;
 
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 @Service
 public class StatisticsValidation {
 
@@ -13,7 +15,20 @@ public class StatisticsValidation {
         return "ROLE_COMPANY".equals(role);
     }
 
+    private boolean isSameCompanyAndActor(UUID company, UUID actor) {
+        return company.equals(actor);
+    }
+
     public boolean isNotGetAllValidation(String role) {
         return !isAdmin(role);
+    }
+
+    public boolean isNotGetValidation(String role, UUID company, UUID actor) {
+        System.out.println("role : "+role);
+        System.out.println("company : "+company);
+        System.out.println("actor : "+actor);
+        System.out.println((isCompany(role) && isSameCompanyAndActor(company,actor)));
+        System.out.println(!(isAdmin(role) || (isCompany(role) && isSameCompanyAndActor(company,actor))));
+        return !(isAdmin(role) || (isCompany(role) && isSameCompanyAndActor(company,actor)));
     }
 }

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/service/StatisticsValidation.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/service/StatisticsValidation.java
@@ -1,0 +1,15 @@
+package com.trillionares.tryit.statistics.domain.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class StatisticsValidation {
+
+    private boolean isAdmin(String role) {
+        return "ROLE_ADMIN".equals(role);
+    }
+
+    private boolean isCompany(String role) {
+        return "ROLE_COMPANY".equals(role);
+    }
+}

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/service/StatisticsValidation.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/domain/service/StatisticsValidation.java
@@ -12,4 +12,8 @@ public class StatisticsValidation {
     private boolean isCompany(String role) {
         return "ROLE_COMPANY".equals(role);
     }
+
+    public boolean isNotGetAllValidation(String role) {
+        return !isAdmin(role);
+    }
 }

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/libs/exception/ErrorCode.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/libs/exception/ErrorCode.java
@@ -26,7 +26,8 @@ public enum ErrorCode {
     INVALID_DATE(400, "날짜가 올바르지 않습니다"),
 
     // Statistics
-    STATISTICS_GET_ALL_FORBIDDEN(403,"통계 전체 조회 권한이 없습니다.");
+    STATISTICS_GET_ALL_FORBIDDEN(403,"통계 전체 조회 권한이 없습니다."),
+    STATISTICS_GET_FORBIDDEN(403,"통계 목록 조회 권한이 없습니다.");
 
     private final int status;
     private final String message;

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/libs/exception/ErrorCode.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/libs/exception/ErrorCode.java
@@ -23,7 +23,10 @@ public enum ErrorCode {
     INVALID_LENGTH(400, "길이가 올바르지 않습니다"),
     INVALID_FORMAT(400, "형식이 올바르지 않습니다"),
     INVALID_RANGE(400, "범위가 올바르지 않습니다"),
-    INVALID_DATE(400, "날짜가 올바르지 않습니다");
+    INVALID_DATE(400, "날짜가 올바르지 않습니다"),
+
+    // Statistics
+    STATISTICS_GET_ALL_FORBIDDEN(403,"통계 전체 조회 권한이 없습니다.");
 
     private final int status;
     private final String message;

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/controller/StatisticsController.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/controller/StatisticsController.java
@@ -32,7 +32,10 @@ public class StatisticsController {
     }
 
     @GetMapping("/statistics/{userId}")
-    public BaseResponse<List<StatisticsGetResponseDto>> getStatistics(@PathVariable("userId") UUID userId) {
-        return BaseResponse.of(HttpStatus.OK.value(), HttpStatus.OK,"통계 목록 조회",statisticsService.getStatistics(userId));
+    public BaseResponse<List<StatisticsGetResponseDto>> getStatistics(
+            @RequestHeader("X-Auth-Role") String role,
+            @RequestHeader("X-Auth-Username") String username,
+            @PathVariable("userId") UUID userId) {
+        return BaseResponse.of(HttpStatus.OK.value(), HttpStatus.OK,"통계 목록 조회",statisticsService.getStatistics(userId,role,username));
     }
 }

--- a/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/controller/StatisticsController.java
+++ b/com.trillionares.tryit.statistics/src/main/java/com/trillionares/tryit/statistics/presentation/controller/StatisticsController.java
@@ -26,8 +26,9 @@ public class StatisticsController {
     }
 
     @GetMapping("/statistics")
-    public BaseResponse<List<StatisticsGetResponseDto>> getAllStatistics() {
-        return BaseResponse.of(HttpStatus.OK.value(), HttpStatus.OK,"통계 전체 조회",statisticsService.getAllStatistics());
+    public BaseResponse<List<StatisticsGetResponseDto>> getAllStatistics(
+            @RequestHeader("X-Auth-Role") String role) {
+        return BaseResponse.of(HttpStatus.OK.value(), HttpStatus.OK,"통계 전체 조회",statisticsService.getAllStatistics(role));
     }
 
     @GetMapping("/statistics/{userId}")


### PR DESCRIPTION
## 연관된 이슈
Close #133 

## 작업 내역
- OpenFeign 의존성 추가 및 설정
- 통계 검증 도메인 서비스 생성
- 통계 전체 조회 검증
- 통계 목록 조회 검증

## 테스트
- [x] API 테스트 

## 문제 및 해결
- 문제 1 : 각 권한에 대한 분기 로직 처리 필요
- 문제 2 : 조회 처리 과정에서 작성자와 행위자 검증 필요
- 문제 3 : 문제 1, 2 코드 추가로 인해 서비스의 역할이 커지게 됨
- 해결 : 권한 및 검증에 대한 책임을 리뷰 검증 도메인 서비스에 할당

## 다음 진행사항

## 리뷰 요구사항
