### PR TITLE
[Feat/gatewat] fix: PathMatch로 경로 읽기 수정 및 관련 설정 빌드그래들에 추가

### DIFF
--- a/com.trillionares.tryit.gateway/build.gradle
+++ b/com.trillionares.tryit.gateway/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework:spring-core:6.2.1'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'


### PR DESCRIPTION
## 연관된 이슈
Close #

## 작업 내역
- 게이트웨이 필터에서 인증제외 경로의 와일드카드를 못읽는 문제 해결

## 테스트
- [x] API 테스트 
- [ ] 테스트 코드 작성

## 문제 및 해결
문제_1: 게이트웨이 필터에서 인증제외 경로의 와일드카드를 못읽어서 인증제외 경로에 인증을 요구하는 일 발생
해결_1: passMatch 추가해서 와일드카드 읽도록 해결

## 다음 진행사항

## 참고사항

![image](https://github.com/user-attachments/assets/625d326a-b974-4d33-baec-24f345727ff3)
```

2025-01-17T16:09:37.482+09:00 DEBUG 21624 --- [gateway-service] [io-19091-exec-6] o.s.c.g.h.RoutePredicateHandlerMapping   : Route matched: auth-service
2025-01-17T16:09:37.482+09:00 DEBUG 21624 --- [gateway-service] [io-19091-exec-6] o.s.c.g.h.RoutePredicateHandlerMapping   : Mapping [Exchange: GET http://localhost:19091/users/internals/ef323d0e-dd40-4aeb-9420-27d52d0256a1] to Route{id='auth-service', uri=lb://auth-service, order=0, predicate=Paths: [/auth/**, /users/**, /auth-service/**], match trailing slash: true, gatewayFilters=[], metadata={}}
2025-01-17T16:09:37.484+09:00 DEBUG 21624 --- [gateway-service] [io-19091-exec-6] o.s.c.g.h.RoutePredicateHandlerMapping   : [50d024d2] Mapped to org.springframework.cloud.gateway.handler.FilteringWebHandler@56f9de3b
2025-01-17T16:09:37.488+09:00 DEBUG 21624 --- [gateway-service] [io-19091-exec-6] o.s.c.g.handler.FilteringWebHandler      : Sorted gatewayFilterFactories: [[GatewayFilterAdapter{delegate=org.springframework.cloud.gateway.filter.RemoveCachedBodyFilter@222d9d4f}, order = -2147483648], [GatewayFilterAdapter{delegate=org.springframework.cloud.gateway.filter.AdaptCachedBodyGlobalFilter@60f662bd}, order = -2147482648], [GatewayFilterAdapter{delegate=org.springframework.cloud.gateway.filter.NettyWriteResponseFilter@3e98b933}, order = -1], [GatewayFilterAdapter{delegate=org.springframework.cloud.gateway.filter.ForwardPathFilter@71e7830a}, order = 0], [GatewayFilterAdapter{delegate=org.springframework.cloud.gateway.filter.GatewayMetricsFilter@305e95a4}, order = 0], [GatewayFilterAdapter{delegate=org.springframework.cloud.gateway.filter.RouteToRequestUrlFilter@4269aad7}, order = 10000], [GatewayFilterAdapter{delegate=org.springframework.cloud.gateway.filter.ReactiveLoadBalancerClientFilter@7d3c22a5}, order = 10150], [GatewayFilterAdapter{delegate=org.springframework.cloud.gateway.filter.LoadBalancerServiceInstanceCookieFilter@369ad7da}, order = 10151], [GatewayFilterAdapter{delegate=org.springframework.cloud.gateway.filter.WebsocketRoutingFilter@3feebf9c}, order = 2147483646], GatewayFilterAdapter{delegate=com.trillionares.tryit.gateway.config.GatewayConfig$$Lambda$713/0x000001d1854b31a8@4fa8bebb}, [GatewayFilterAdapter{delegate=org.springframework.cloud.gateway.filter.NettyRoutingFilter@344f9467}, order = 2147483647], [GatewayFilterAdapter{delegate=org.springframework.cloud.gateway.filter.ForwardRoutingFilter@a4df251}, order = 2147483647]]
2025-01-17T16:09:37.661+09:00  INFO 21624 --- [gateway-service] [io-19091-exec-6] c.t.tryit.gateway.filter.JwtAuthFilter   : JwtAuthFilter 실행됨
2025-01-17T16:09:37.662+09:00  INFO 21624 --- [gateway-service] [io-19091-exec-6] c.t.tryit.gateway.filter.JwtAuthFilter   : 요청 경로: /users/internals/ef323d0e-dd40-4aeb-9420-27d52d0256a1
2025-01-17T16:09:37.662+09:00  INFO 21624 --- [gateway-service] [io-19091-exec-6] c.t.tryit.gateway.filter.JwtAuthFilter   : 인증 제외 경로에 포함 여부: true
2025-01-17T16:09:37.662+09:00  INFO 21624 --- [gateway-service] [io-19091-exec-6] c.t.tryit.gateway.filter.JwtAuthFilter   : 인증 제외 경로 접근: /users/internals/ef323d0e-dd40-4aeb-9420-27d52d0256a1
```
![image](https://github.com/user-attachments/assets/0528f648-9c1f-4cf7-a605-c43fdf998b8b)

