### PR TITLE
[Refactor/enh fail logic] 알림 실패시 재시도 로직 구현

### DIFF
--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/application/dto/slack/SlackNotificationSender.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/application/dto/slack/SlackNotificationSender.java
@@ -15,12 +15,12 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 public class SlackNotificationSender {
 
-  private final ExceptionConverter exceptionConverter;
   @Value("${slack.webhook.url}")
   private String webhookUrl;
 
   private final RestTemplate restTemplate;
   private final NotificationRepository notificationRepository;
+  private final ExceptionConverter exceptionConverter;
 
   public void sendNotification(Notification notification, String slackId, String status) {
 

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/application/service/NotificationService.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/application/service/NotificationService.java
@@ -32,23 +32,69 @@ public class NotificationService {
   private final AuthClient authClient;
   private final NotificationRoleValidation roleValidation;
 
+  /**
+   * Kafka 이벤트를 기반으로 알림을 생성하고 Slack으로 발송합니다.
+   * @param event 체험단 신청(submission) 카프카 이벤트를 통해 받아온 값
+   */
   @Transactional
   public void createNotificationFromSubmissionEvent(SubmissionKafkaEvent event) {
 
-    if (notificationRepository.existsByMessageId(event.getMessageId())) {
-      throw new GlobalException(ErrorCode.DUPLICATE_MESSAGE_ID);
-    }
+    validateNotification(event);
+    Notification notification = notificationRepository.save(
+        convertEventToNotification(event));
 
-    // 알림 엔티티 저장
-    Notification notification = convertEventToNotification(event);
-    Notification savedNotification = notificationRepository.save(notification);
-
-    String slackId = getSlackId(savedNotification);
-
-    // 슬랙 알림 발송
-    slackNotificationSender.sendNotification(savedNotification, slackId, event.getStatus());
+    sendNotificationToSlack(notification, event.getStatus());
   }
 
+  /**
+   * 알림 유효성을 검사합니다 (동일한 messageId로 발송된 알림이 있는지 확인, 실패 경우 재시도 횟수 검증)
+   * @param event 체험단 신청(submission) 카프카 이벤트를 통해 받아온 값
+   */
+  private void validateNotification(SubmissionKafkaEvent event) {
+    notificationRepository.findByMessageId(event.getMessageId())
+        .ifPresent(notification -> {
+          if (notification.getNotificationStatus() == NotificationStatus.SENT) { //
+            throw new GlobalException(ErrorCode.DUPLICATE_MESSAGE_ID);
+          }
+          validateRetryCount(notification);
+        });
+  }
+
+  /**
+   * 알림 재시도 횟수가 3회를 초과 했는지 확인합니다.
+   * @param notification 알림 객체
+   */
+  private void validateRetryCount(Notification notification) {
+    if (notification.getAttemptCount() >= 3) {
+      log.warn("재시도 횟수 3회 초과 {}", notification.getMessageId());
+      throw new GlobalException(ErrorCode.MAX_RETRY_EXCEEDED);
+    }
+  }
+
+  /**
+   * 생성된 알림을 Slack으로 발송합니다.
+   * @param notification 알림 객체
+   * @param status 알림 상태 정보
+   */
+  private void sendNotificationToSlack(Notification notification, String status) {
+    try {
+      String slackId = getSlackId(notification);
+      slackNotificationSender.sendNotification(notification, slackId, status);
+      notification.markAsDelivered();
+
+    } catch (Exception e) {
+      notification.increaseAttemptCount();
+      log.error("알림 발송 실패, attempt {}: {}",
+          notification.getAttemptCount(), e.getMessage());
+      throw e;
+    }
+  }
+
+  /**
+   * Slack ID를 구하는 메서드
+   * @param notification 알림 객체
+   * @return Auth Service에서 조회한 Slack ID
+   */
   private String getSlackId(Notification notification) {
 
     BaseResponse<FeignUserIdResponseDto> response = authClient.getUserId(
@@ -56,16 +102,19 @@ public class NotificationService {
 
     FeignUserIdResponseDto userDto = response.getData();
     String slackId = userDto.getSlackId();
-
     log.info("slackId {}", slackId);
 
     if (slackId == null || slackId.isEmpty()) { // TODO: Feign error 추가 필요
       throw new GlobalException(ErrorCode.SLACK_ID_NOT_FOUND);
     }
-
     return slackId;
   }
 
+  /**
+   * Kafka 이벤트 데이터를 알림 엔티티로 변환하는 메서드 입니다.
+   * @param event Kafka 이벤트 데이터
+   * @return 생성된 알림 데이터
+   */
   private Notification convertEventToNotification(SubmissionKafkaEvent event) {
 
     return Notification.builder()

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/domain/model/Notification.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/domain/model/Notification.java
@@ -23,6 +23,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {
 
+  private static final int MAX_ATTEMPT_COUNT = 3;
+
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   @Column(name = "notification_id", updatable = false)
@@ -57,17 +59,20 @@ public class Notification extends BaseEntity {
 
   public void increaseAttemptCount() {
     this.attemptCount++;
-    updateStatusBasedOnAttempt();
-  }
-
-  private void updateStatusBasedOnAttempt() {
-    if (this.attemptCount >= 3) { // 0, 1, 2 최대 3회
-      this.notificationStatus = NotificationStatus.FAILED;
-    }
+    updateNotificationStatus();
   }
 
   public void markAsDelivered() {
     this.notificationStatus = NotificationStatus.SENT;
+  }
+
+  public void updateNotificationStatus() {
+    if (this.attemptCount >= MAX_ATTEMPT_COUNT) {
+      this.notificationStatus = NotificationStatus.FAILED; // 시도 횟수 3번 이상 실패
+
+    } else if (this.notificationStatus != NotificationStatus.SENT) {
+      this.notificationStatus = NotificationStatus.PENDING;
+    }
   }
 
   @Builder

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/domain/model/Notification.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/domain/model/Notification.java
@@ -49,9 +49,6 @@ public class Notification extends BaseEntity {
   @Column(name = "expiry_date")
   private LocalDateTime expiryDate;
 
-  @Column(name = "submission_time")
-  private LocalDateTime submissionTime;
-
   @PrePersist
   protected void onCreate() {
     this.expiryDate = LocalDateTime.now().plusMonths(3); // 저장일로 부터 3개월
@@ -81,6 +78,5 @@ public class Notification extends BaseEntity {
     this.userId = userId;
     this.submissionId = submissionId;
     this.messageId = messageId;
-    this.submissionTime = submissionTime;
   }
 }

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/domain/model/Notification.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/domain/model/Notification.java
@@ -73,7 +73,7 @@ public class Notification extends BaseEntity {
   }
 
   @Builder
-  public Notification(UUID notificationId, UUID userId, UUID submissionId, String messageId, LocalDateTime submissionTime) {
+  public Notification(UUID notificationId, UUID userId, UUID submissionId, String messageId) {
     this.notificationId = notificationId;
     this.userId = userId;
     this.submissionId = submissionId;

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/infrastructure/messaging/event/SubmissionKafkaEvent.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/infrastructure/messaging/event/SubmissionKafkaEvent.java
@@ -1,6 +1,5 @@
 package com.trillionares.tryit.notification.infrastructure.messaging.event;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
@@ -14,7 +13,6 @@ public class SubmissionKafkaEvent {
   private UUID userId;
   private UUID recruitmentId;
   private String status;
-  private LocalDateTime submissionTime;
 
   @Setter
   private String messageId;

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/infrastructure/persistence/NotificationRepository.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/infrastructure/persistence/NotificationRepository.java
@@ -2,6 +2,7 @@ package com.trillionares.tryit.notification.infrastructure.persistence;
 
 import com.trillionares.tryit.notification.domain.model.Notification;
 import com.trillionares.tryit.notification.domain.repository.NotificationRepositoryCustom;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,6 +13,6 @@ public interface NotificationRepository extends
     JpaRepository<Notification, UUID>,
     NotificationRepositoryCustom {
 
-  boolean existsByMessageId(String messageId);
+  Optional<Notification> findByMessageId(String messageId);
 
 }

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/libs/exception/ErrorCode.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/libs/exception/ErrorCode.java
@@ -16,18 +16,14 @@ public enum ErrorCode {
   FILE_PROCESSING_ERROR(500, "파일 처리 중 오류가 발생했습니다"),
   EXTERNAL_SERVICE_ERROR(500, "외부 서비스 연동 중 오류가 발생했습니다"),
 
-  // 데이터 검증 관련
-  INVALID_LENGTH(400, "길이가 올바르지 않습니다"),
-  INVALID_FORMAT(400, "형식이 올바르지 않습니다"),
-  INVALID_RANGE(400, "범위가 올바르지 않습니다"),
-  INVALID_DATE(400, "날짜가 올바르지 않습니다"),
-
   // notification
   INVALID_SUBMISSION_STATUS(400, "허용되지 않는 체험단 신청 상태입니다."),
   NOTIFICATION_NOT_FOUND(404, "해당 알림은 존재하지 않습니다."),
   SLACK_NOTIFICATION_FAILED(500, "알림 생성이 실패되었습니다."),
   SLACK_ID_NOT_FOUND(404, "해당 슬랙 ID는 존재하지 않습니다."),
-  DUPLICATE_MESSAGE_ID(404, "중복된 messageID 이므로 알림 시도가 실패됩니다.")
+  DUPLICATE_MESSAGE_ID(404, "중복된 messageID 이므로 알림 시도가 실패됩니다."),
+  MAX_RETRY_EXCEEDED(400, "재시도 횟수 3회를 초과하였습니다")
+
   ;
 
   private final int status;

--- a/com.trillionares.tryit.notification/src/test/java/com/trillionares/tryit/notification/KafkaTestConfig.java
+++ b/com.trillionares.tryit.notification/src/test/java/com/trillionares/tryit/notification/KafkaTestConfig.java
@@ -1,6 +1,6 @@
 package com.trillionares.tryit.notification;
 
-import com.trillionares.tryit.notification.infrastructure.messaging.event.SubmissionSelectedEvent;
+import com.trillionares.tryit.notification.infrastructure.messaging.event.SubmissionKafkaEvent;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -14,13 +14,13 @@ import org.springframework.kafka.support.serializer.JsonSerializer;
 @TestConfiguration
 public class KafkaTestConfig {
   @Bean
-  public KafkaTemplate<String, SubmissionSelectedEvent> kafkaTemplate(
-      ProducerFactory<String, SubmissionSelectedEvent> producerFactory) {
+  public KafkaTemplate<String, SubmissionKafkaEvent> kafkaTemplate(
+      ProducerFactory<String, SubmissionKafkaEvent> producerFactory) {
     return new KafkaTemplate<>(producerFactory);
   }
 
   @Bean
-  public ProducerFactory<String, SubmissionSelectedEvent> producerFactory() {
+  public ProducerFactory<String, SubmissionKafkaEvent> producerFactory() {
     Map<String, Object> props = new HashMap<>();
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);

--- a/com.trillionares.tryit.notification/src/test/java/com/trillionares/tryit/notification/NotificationServiceTest.java
+++ b/com.trillionares.tryit.notification/src/test/java/com/trillionares/tryit/notification/NotificationServiceTest.java
@@ -1,74 +1,106 @@
-//package com.trillionares.tryit.notification;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//
-//import com.trillionares.tryit.notification.application.service.NotificationService;
-//import com.trillionares.tryit.notification.application.service.SlackNotificationSender;
-//import com.trillionares.tryit.notification.domain.model.Notification;
-//import com.trillionares.tryit.notification.domain.repository.NotificationRepositoryImpl;
-//import com.trillionares.tryit.notification.infrastructure.messaging.event.SubmissionSelectedEvent;
-//import com.trillionares.tryit.notification.infrastructure.persistence.NotificationRepository;
-//import java.time.LocalDateTime;
-//import java.util.UUID;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.boot.test.context.SpringBootTest;
-//import org.springframework.test.context.ActiveProfiles;
-//
-//@ActiveProfiles("test")
-//@ExtendWith(MockitoExtension.class)
-//public class NotificationServiceTest {
-//
-//  @Mock
-//  private NotificationRepository notificationRepository;
-//
-//  @InjectMocks
-//  private NotificationService notificationService;
-//
-//  @Mock
-//  private SlackNotificationSender slackNotificationSender;
-//
-//  private SubmissionSelectedEvent createSubmissionSelectedEvent(String status) {
-//    return new SubmissionSelectedEvent(
-//        UUID.randomUUID(),              // submissionId
-//        UUID.randomUUID(),              // userId
-//        UUID.randomUUID(),              // recruitmentId
-//        status,                         // status
-//        LocalDateTime.now(),            // submissionTime
-//        UUID.randomUUID(),              // messageId
-//        LocalDateTime.now()             // eventTimestamp
-//    );
-//  }
-//
-//  @Test
-//  void shouldSendSlackNotificationWhenEventReceived() {
-//    // given
-//    // 이벤트 발생
-//    SubmissionSelectedEvent event = createSubmissionSelectedEvent("SELECTED");
-//
-//    // notification 저장 시 반환될 객체 생성
-//
-//    Notification mockNotification = Notification.builder()
-//            .notificationId(UUID.randomUUID())
-//            .userId(event.getUserId())
-//            .submissionId(event.getSubmissionId())
-//            .build();
-//
-//    when(notificationRepository.save(any(Notification.class)))
-//        .thenReturn(mockNotification);
-//
-//    // when
-//    notificationService.createNotificationFromSubmissionEvent(event);
-//
-//    // then
-//    verify(notificationRepository).save(any(Notification.class));
-//   // verify(slackNotificationSender).sendNotification(any(Notification.class));
-//
-//  }
-//}
+package com.trillionares.tryit.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trillionares.tryit.notification.application.dto.slack.SlackNotificationSender;
+import com.trillionares.tryit.notification.application.service.NotificationService;
+import com.trillionares.tryit.notification.domain.model.Notification;
+import com.trillionares.tryit.notification.infrastructure.messaging.event.SubmissionKafkaEvent;
+import com.trillionares.tryit.notification.infrastructure.persistence.NotificationRepository;
+import com.trillionares.tryit.notification.libs.client.auth.AuthClient;
+import com.trillionares.tryit.notification.libs.client.auth.FeignUserIdResponseDto;
+import com.trillionares.tryit.notification.presentation.dto.BaseResponse;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class NotificationServiceTest {
+
+  @Mock
+  private NotificationRepository notificationRepository;
+
+  @InjectMocks
+  private NotificationService notificationService;
+
+  @Mock
+  private SlackNotificationSender slackNotificationSender;
+
+  @Mock
+  private AuthClient authClient;
+
+  @Test
+  void 알림_발송_성공_테스트() throws JsonProcessingException {
+    // given
+    String messageId = "test-message-id";
+    String slackId = "@1111111111";
+
+    String payload = """
+        {
+            "submissionId": "eacad322-798e-4744-a4a4-69ebbdb9e0e4",
+            "userId": "0823f7ce-ba76-404c-8373-d2b6f4348d94",
+            "recruitmentId": "a96e1693-9e9a-4077-beb9-a3ea6f7f256c",
+            "status": "SELECTED"
+        }
+        """;
+
+    // 카프카 역직렬화
+    ObjectMapper objectMapper = new ObjectMapper();
+    SubmissionKafkaEvent event = objectMapper.readValue(payload, SubmissionKafkaEvent.class);
+    event.setMessageId(messageId);
+
+    UUID userId = UUID.fromString("0823f7ce-ba76-404c-8373-d2b6f4348d94");
+    UUID submissionId = UUID.fromString("eacad322-798e-4744-a4a4-69ebbdb9e0e4");
+
+    Notification mockNotification = Notification.builder()
+        .messageId(messageId)
+        .submissionId(UUID.fromString("a2411206-94f7-46e3-942c-83b1cd6179b7"))
+        .userId(UUID.fromString("0075ac5e-b212-4419-891b-9e4a0b4190cb"))
+        .build();
+
+    // feign user 관련 모킹
+    FeignUserIdResponseDto userDto = mock(FeignUserIdResponseDto.class); // 가짜 객체 생성
+    when(userDto.getSlackId()).thenReturn(slackId);
+
+    BaseResponse<FeignUserIdResponseDto> authResponse = mock(BaseResponse.class);
+    when(authResponse.getData()).thenReturn(userDto);
+
+    when(authClient.getUserId(any(UUID.class)))
+        .thenReturn(authResponse);
+
+    // repository 모킹
+    when(notificationRepository.save(any(Notification.class)))
+        .thenReturn(mockNotification);
+
+    when(notificationRepository.findByMessageId(messageId))
+        .thenReturn(Optional.empty());
+
+    // ArgumentCaptor 준비
+    ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
+
+    // when
+    notificationService.createNotificationFromSubmissionEvent(event);
+
+    // then
+    // 저장된 Notification 객체 캡처 및 검증
+    verify(notificationRepository).save(notificationCaptor.capture());
+    Notification savedNotification = notificationCaptor.getValue();
+
+    assertThat(savedNotification.getMessageId()).isEqualTo(messageId);
+    assertThat(savedNotification.getUserId()).isEqualTo(userId);
+    assertThat(savedNotification.getSubmissionId()).isEqualTo(submissionId);
+  }
+}

--- a/com.trillionares.tryit.notification/src/test/java/com/trillionares/tryit/notification/NotificationTest.java
+++ b/com.trillionares.tryit.notification/src/test/java/com/trillionares/tryit/notification/NotificationTest.java
@@ -2,7 +2,7 @@ package com.trillionares.tryit.notification;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trillionares.tryit.notification.domain.repository.NotificationRepositoryImpl;
-import com.trillionares.tryit.notification.infrastructure.messaging.event.SubmissionSelectedEvent;
+import com.trillionares.tryit.notification.infrastructure.messaging.event.SubmissionKafkaEvent;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,7 +12,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 public class NotificationTest {
 
   @Autowired
-  private KafkaTemplate<String, SubmissionSelectedEvent> kafkaTemplate;
+  private KafkaTemplate<String, SubmissionKafkaEvent> kafkaTemplate;
 
   @Autowired
   private NotificationRepositoryImpl notificationQueryRepositoryImpl;


### PR DESCRIPTION
## 연관된 이슈
Close #202 

## 작업 내역
- 알림 재시도 횟수(3회) 관련해서 업데이트 하는 메서드가 존재했지만, 실제로 상태를 변경해주는 로직이 없어 동작하고 있지 않아 도메인 로직에 상태 변경 관련된 로직을 추가
- Notification 서비스 로직 > 알림 생성 하는 로직에서(슬랙아이디 조회, 재시도 횟수 체크 로직과 같이 여러개의 기능이 함께 있어 여러개의 메서드로 분리
- 테스트 코드 함께 맞춰서 수정

## 테스트
- [X] API 테스트 
- [X] 테스트 코드 작성

## 문제 및 해결
(작업 중 발생한 문제와 그 해결 방법에 대해 간단히 설명해주세요.)

## 다음 진행사항

## 리뷰 요구사항
