### PR TITLE
feat: 모집 완료 시간 조회 기능 추가

### DIFF
--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/model/recruitment/Recruitment.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/model/recruitment/Recruitment.java
@@ -3,6 +3,7 @@ package com.trillionares.tryit.product.domain.model.recruitment;
 import com.trillionares.tryit.product.domain.common.base.BaseEntity;
 import com.trillionares.tryit.product.domain.model.recruitment.type.RecruitmentStatus;
 import jakarta.persistence.*;
+import java.time.Duration;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -51,6 +52,12 @@ public class Recruitment extends BaseEntity {
     @Column(name = "max_participants", nullable = false)
     private Long maxParticipants;
 
+    @Column(name = "actual_end_date ")
+    private LocalDateTime actualEndDate;
+
+    @Column(name = "completion_time")
+    private long completionTime;
+
     public void updateRecruitment(String title, String description, LocalDateTime startTime,
                                   Long during, LocalDateTime endTime, Long maxParticipants) {
         if (title != null) {
@@ -79,6 +86,21 @@ public class Recruitment extends BaseEntity {
 
     public void updateCurrentParticipants(long currentParticipants) {
         this.currentParticipants = currentParticipants;
+    }
+
+    public void updateActualEndDate(LocalDateTime actualEndDate) {
+        this.actualEndDate = actualEndDate;
+    }
+
+    public void updateCompletionTime(long completionTime) {
+        this.completionTime = completionTime;
+    }
+
+    public long calculateDurationInMillis() {
+        if (this.actualEndDate != null && this.recruitmentStartDate != null) {
+            return Duration.between(this.recruitmentStartDate, this.actualEndDate).toMillis();
+        }
+        return 0;
     }
 }
 

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/repository/RecruitmentRepository.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/repository/RecruitmentRepository.java
@@ -13,4 +13,6 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, UUID>,
     @Query("SELECT r.userId FROM Recruitment r WHERE r.recruitmentId = :recruitmentId")
     Optional<UUID> findOwnerIdByRecruitmentId(@Param("recruitmentId") UUID recruitmentId);
 
+    Optional<Recruitment> findByProductId(UUID productId);
+
 }

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/RecruitmentController.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/RecruitmentController.java
@@ -6,6 +6,7 @@ import com.trillionares.tryit.product.presentation.dto.common.base.BaseResponseD
 import com.trillionares.tryit.product.presentation.dto.request.CreateRecruitmentRequest;
 import com.trillionares.tryit.product.presentation.dto.request.UpdateRecruitmentRequest;
 import com.trillionares.tryit.product.presentation.dto.request.UpdateRecruitmentStatusRequest;
+import com.trillionares.tryit.product.presentation.dto.response.GetCompletionTimeResponse;
 import com.trillionares.tryit.product.presentation.dto.response.GetRecruitmentResponse;
 import com.trillionares.tryit.product.presentation.dto.response.RecruitmentIdResponse;
 import com.trillionares.tryit.product.presentation.dto.response.UpdateRecruitmentStatusResponse;
@@ -95,5 +96,12 @@ public class RecruitmentController {
         RecruitmentExistAndStatusDto responseDto = recruitmentService.isExistRecruitmentById(recruitmentId);
 
         return BaseResponseDto.from(HttpStatus.OK.value(), HttpStatus.OK, "OK", responseDto);
+    }
+
+    @GetMapping("/product/{productId}")
+    public ResponseEntity<GetCompletionTimeResponse> getCompletionTime(
+            @PathVariable UUID productId
+    ) {
+        return ResponseEntity.ok(recruitmentService.getCompletionTime(productId));
     }
 }

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/response/GetCompletionTimeResponse.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/response/GetCompletionTimeResponse.java
@@ -1,0 +1,24 @@
+package com.trillionares.tryit.product.presentation.dto.response;
+
+import com.trillionares.tryit.product.domain.model.recruitment.Recruitment;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.springframework.cglib.core.Local;
+
+public record GetCompletionTimeResponse(
+        UUID recruitmentId,
+        LocalDateTime recruitmentStartDate,
+        LocalDateTime recruitmentEndDate,
+        LocalDateTime actualEndDate,
+        long completionTime
+) {
+    public static GetCompletionTimeResponse fromEntity(Recruitment recruitment) {
+        return new GetCompletionTimeResponse(
+                recruitment.getRecruitmentId(),
+                recruitment.getRecruitmentStartDate(),
+                recruitment.getRecruitmentEndDate(),
+                recruitment.getActualEndDate(),
+                recruitment.getCompletionTime()
+        );
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
Close #262 

## 작업 내역
- Recruitment 엔티티에 actualEndDate와 completionTime 필드 추가
- RecruitmentService에 모집 완료 시간 계산 및 저장 로직 구현
- RecruitmentController에 모집 완료 시간 조회 API 엔드포인트 추가
- /recruitments/product/{productId} 호출 시 GetCompletionTimeResponse 반환

## 테스트
- [x] API 테스트 
- [ ] 테스트 코드 작성

## 문제 및 해결
- 모집 상태가 ENDED로 변경될 때 actualEndDate와 completionTime을 업데이트하는 로직 추가
- Redis를 통한 상태 업데이트 시에도 동일한 로직 적용
