### PR TITLE
[Refactor/user list] 사용자 목록 조회에 검색필터 추가

### DIFF
--- a/com.trillionares.tryit.auth/src/main/java/com/trillionares/tryit/auth/application/service/UserService.java
+++ b/com.trillionares.tryit.auth/src/main/java/com/trillionares/tryit/auth/application/service/UserService.java
@@ -12,6 +12,8 @@ import com.trillionares.tryit.auth.presentation.dto.requestDto.SignUpRequestDto;
 import com.trillionares.tryit.auth.presentation.dto.requestDto.UserInfoUpdateReqDto;
 import com.trillionares.tryit.auth.presentation.dto.responseDto.UserResponseDto;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -128,11 +130,12 @@ public class UserService {
   // 사용자 목록 조회 queryDsl+paging
   @Transactional(readOnly = true)
   @PreAuthorize("hasAuthority('ADMIN')")
-  public PagedModel<UserResponseDto> getUsers(List<UUID> uuidList, Predicate predicate,
+  public PagedModel<UserResponseDto> getUsers(List<UUID> uuidList, String username, String email, Role role,
+      LocalDateTime startDateTime, LocalDateTime endDateTime, Predicate predicate,
       Pageable pageable) {
 
     Page<UserResponseDto> userResponseDtoPage
-        = userRepository.findAllByConditions(uuidList, predicate, pageable);
+        = userRepository.findAllByConditions(uuidList, username, email, role, startDateTime, endDateTime, predicate, pageable);
 
     return new PagedModel<>(userResponseDtoPage);
   }

--- a/com.trillionares.tryit.auth/src/main/java/com/trillionares/tryit/auth/application/service/UserService.java
+++ b/com.trillionares.tryit.auth/src/main/java/com/trillionares/tryit/auth/application/service/UserService.java
@@ -97,7 +97,7 @@ public class UserService {
     userRepository.save(user); // 변경 사항 저장
   }
 
-  @Cacheable(cacheNames = "userCache", key = "#username")
+  @Cacheable(cacheNames = "userCache", key = "#username", unless = "#result == null")
   @Transactional(readOnly = true)
   public InfoByUsernameResponseDto getUserByUsername(String username) {
     log.info("캐싱 적용 전, DB에서 사용자 정보 조회: {}", username); // 캐싱 여부 확인용
@@ -107,7 +107,7 @@ public class UserService {
     return new InfoByUsernameResponseDto(user);
   }
 
-  @Cacheable(cacheNames = "userCache", key = "#userId")
+  @Cacheable(cacheNames = "userCache", key = "#userId", unless = "#result == null")
   @Transactional(readOnly = true)
   public UserResponseDto getUser(UUID userId) {
     log.info("캐싱 적용 전, DB에서 사용자 정보 조회: {}", userId); // 캐싱 여부 확인용
@@ -117,7 +117,7 @@ public class UserService {
     return new UserResponseDto(user);
   }
 
-  @Cacheable(cacheNames = "userCache", key = "#userId")
+  @Cacheable(cacheNames = "userCache", key = "#userId", unless = "#result == null")
   @Transactional(readOnly = true)
   public UserResponseDto getInternalUser(UUID userId) {
     log.info("캐싱 적용 전, DB에서 내부용 사용자 정보 조회: {}", userId); // 캐싱 여부 확인용

--- a/com.trillionares.tryit.auth/src/main/java/com/trillionares/tryit/auth/domain/repository/UserRepositoryCustom.java
+++ b/com.trillionares.tryit.auth/src/main/java/com/trillionares/tryit/auth/domain/repository/UserRepositoryCustom.java
@@ -1,7 +1,10 @@
 package com.trillionares.tryit.auth.domain.repository;
 
 import com.querydsl.core.types.Predicate;
+import com.trillionares.tryit.auth.domain.model.Role;
 import com.trillionares.tryit.auth.presentation.dto.responseDto.UserResponseDto;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -10,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 public interface UserRepositoryCustom {
 
   Page<UserResponseDto> findAllByConditions(
-      List<UUID> userIdList, Predicate predicate, Pageable pageable);
+      List<UUID> userIdList, String username, String email, Role role,
+      LocalDateTime startDateTime, LocalDateTime endDateTime, Predicate predicate, Pageable pageable);
 
 }

--- a/com.trillionares.tryit.auth/src/main/java/com/trillionares/tryit/auth/domain/repository/UserRepositoryCustomImpl.java
+++ b/com.trillionares.tryit.auth/src/main/java/com/trillionares/tryit/auth/domain/repository/UserRepositoryCustomImpl.java
@@ -9,8 +9,11 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.trillionares.tryit.auth.domain.model.QUser;
+import com.trillionares.tryit.auth.domain.model.Role;
 import com.trillionares.tryit.auth.presentation.dto.responseDto.UserResponseDto;
 import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -30,7 +33,8 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom{
 
   @Override
   public Page<UserResponseDto> findAllByConditions(
-      List<UUID> userIdList, Predicate predicate, Pageable pageable
+      List<UUID> userIdList, String username, String email, Role role,
+      LocalDateTime startDateTime, LocalDateTime endDateTime, Predicate predicate, Pageable pageable
   ) {
 
     QUser user = QUser.user;

--- a/com.trillionares.tryit.auth/src/main/java/com/trillionares/tryit/auth/domain/repository/UserRepositoryCustomImpl.java
+++ b/com.trillionares.tryit.auth/src/main/java/com/trillionares/tryit/auth/domain/repository/UserRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.trillionares.tryit.auth.domain.repository;
 
+import com.trillionares.tryit.auth.domain.model.QUser;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -8,11 +9,9 @@ import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.trillionares.tryit.auth.domain.model.QUser;
 import com.trillionares.tryit.auth.domain.model.Role;
 import com.trillionares.tryit.auth.presentation.dto.responseDto.UserResponseDto;
 import jakarta.persistence.EntityManager;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,6 +43,26 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom{
     // userIdList가 비어있지 않으면 해당 ID들만 조회
     if (userIdList != null && !userIdList.isEmpty()) {
       builder.and(user.userId.in(userIdList));
+    }
+
+    // username 조건
+    if (username != null && !username.isEmpty()) {
+      builder.and(user.username.containsIgnoreCase(username));
+    }
+
+    // email 조건
+    if (userIdList != null && !email.isEmpty()) {
+      builder.and(user.email.containsIgnoreCase(email));
+    }
+
+    // role 조건
+    if (role != null) {
+      builder.and(user.role.eq(role));
+    }
+
+    // 날짜 조건
+    if (startDateTime != null && endDateTime != null) {
+      builder.and(user.createdAt.between(startDateTime, endDateTime));
     }
 
     // isDeleted가 false인 사용자만 조회

--- a/com.trillionares.tryit.auth/src/main/java/com/trillionares/tryit/auth/infrastructure/config/builder/UserPredicateBuilder.java
+++ b/com.trillionares.tryit.auth/src/main/java/com/trillionares/tryit/auth/infrastructure/config/builder/UserPredicateBuilder.java
@@ -1,0 +1,50 @@
+package com.trillionares.tryit.auth.infrastructure.config.builder;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import com.trillionares.tryit.auth.domain.model.QUser;
+import com.trillionares.tryit.auth.domain.model.Role;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public class UserPredicateBuilder {
+  public static Predicate createPredicate(
+      List<UUID> userIdList, String username, String email, Role role,
+      LocalDateTime startDateTime, LocalDateTime endDateTime) {
+
+    QUser user = QUser.user;
+    BooleanBuilder builder = new BooleanBuilder();
+
+    // userIdList 조건
+    if (userIdList != null && !userIdList.isEmpty()) {
+      builder.and(user.userId.in(userIdList));
+    }
+
+    // username 조건
+    if (username != null && !username.isEmpty()) {
+      builder.and(user.username.containsIgnoreCase(username));
+    }
+
+    // email 조건
+    if (userIdList != null && !email.isEmpty()) {
+      builder.and(user.email.containsIgnoreCase(email));
+    }
+
+    // role 조건
+    if (role != null) {
+      builder.and(user.role.eq(role));
+    }
+
+    // 날짜 조건
+    if (startDateTime != null && endDateTime != null) {
+      builder.and(user.createdAt.between(startDateTime, endDateTime));
+    }
+
+    // isDeleted == false 조건 추가
+    builder.and(user.isDeleted.eq(false));
+
+    return builder;
+  }
+
+}

--- a/com.trillionares.tryit.auth/src/main/java/com/trillionares/tryit/auth/presentation/controller/UserController.java
+++ b/com.trillionares.tryit.auth/src/main/java/com/trillionares/tryit/auth/presentation/controller/UserController.java
@@ -57,7 +57,7 @@ public class UserController {
   }
 
   @PutMapping("/{userId}")
-  public BaseResponse<UserResponseDto> updateUserInfo(@PathVariable UUID userId,
+  public BaseResponse<UserResponseDto> updateUserInfo(@PathVariable("userId") UUID userId,
       @Valid @RequestBody UserInfoUpdateReqDto reqDto,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     userService.updateUserInfo(userDetails.getUserId(), reqDto);
@@ -68,7 +68,7 @@ public class UserController {
   }
 
   @DeleteMapping("/{userId}")
-  public BaseResponse deleteUser(@PathVariable UUID userId,
+  public BaseResponse deleteUser(@PathVariable("userId") UUID userId,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     userService.deleteUser(userDetails.getUserId());
 
@@ -76,19 +76,19 @@ public class UserController {
   }
 
   @GetMapping("/internals/username/{username}") // 내부통신용으로 인증제외됨
-  public BaseResponse<InfoByUsernameResponseDto> getUserByUsername(@PathVariable String username) {
+  public BaseResponse<InfoByUsernameResponseDto> getUserByUsername(@PathVariable("username") String username) {
     InfoByUsernameResponseDto resDto = userService.getUserByUsername(username);
     return BaseResponse.of(200, HttpStatus.OK, "사용자 정보 조회에 성공하였습니다.", resDto);
   }
 
   @GetMapping("/{userId}")
-  public BaseResponse<UserResponseDto> getUser(@PathVariable UUID userId) {
+  public BaseResponse<UserResponseDto> getUser(@PathVariable("userId") UUID userId) {
     UserResponseDto resDto = userService.getUser(userId);
     return BaseResponse.of(200, HttpStatus.OK, "사용자가 조회되었습니다.", resDto);
   }
 
   @GetMapping("/internals/{userId}")  // 내부통신용으로 인증제외됨
-  public BaseResponse<UserResponseDto> getInternalUser(@PathVariable UUID userId) {
+  public BaseResponse<UserResponseDto> getInternalUser(@PathVariable("userId") UUID userId) {
     UserResponseDto resDto = userService.getInternalUser(userId);
     return BaseResponse.of(200, HttpStatus.OK, "사용자가 조회되었습니다.", resDto);
   }

--- a/com.trillionares.tryit.auth/src/main/java/com/trillionares/tryit/auth/presentation/controller/UserController.java
+++ b/com.trillionares.tryit.auth/src/main/java/com/trillionares/tryit/auth/presentation/controller/UserController.java
@@ -4,6 +4,7 @@ package com.trillionares.tryit.auth.presentation.controller;
 import com.querydsl.core.types.Predicate;
 import com.trillionares.tryit.auth.application.dto.InfoByUsernameResponseDto;
 import com.trillionares.tryit.auth.application.service.UserService;
+import com.trillionares.tryit.auth.domain.model.Role;
 import com.trillionares.tryit.auth.infrastructure.config.CustomUserDetails;
 import com.trillionares.tryit.auth.presentation.dto.BaseResponse;
 import com.trillionares.tryit.auth.presentation.dto.requestDto.PasswordUpdateReqDto;
@@ -11,6 +12,8 @@ import com.trillionares.tryit.auth.presentation.dto.requestDto.SignUpRequestDto;
 import com.trillionares.tryit.auth.presentation.dto.requestDto.UserInfoUpdateReqDto;
 import com.trillionares.tryit.auth.presentation.dto.responseDto.UserResponseDto;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -93,9 +96,24 @@ public class UserController {
   @GetMapping("/userlists")
   public BaseResponse<PagedModel<UserResponseDto>> getUsers(
       @RequestParam(required = false) List<UUID> uuidList,
+      @RequestParam(required = false) String username,
+      @RequestParam(required = false) String email,
+      @RequestParam(required = false) Role role,
+      @RequestParam(required = false) LocalDate startDate, //우선은 사용자 편의를 위해 시간제외하고 받음
+      @RequestParam(required = false) LocalDate endDate,  //우선은 사용자 편의를 위해 시간제외하고 받음
       @RequestParam(required = false) Predicate predicate,
       Pageable pageable) {
-    PagedModel<UserResponseDto> response = userService.getUsers(uuidList, predicate,
+
+    // LocalDate -> LocalDateTime 변환
+    LocalDateTime startDateTime = (startDate != null)
+        ? startDate.atStartOfDay()
+        : null;
+
+    LocalDateTime endDateTime = (endDate != null)
+        ? endDate.atTime(23, 59, 59)
+        : null;
+
+    PagedModel<UserResponseDto> response = userService.getUsers(uuidList, username, email, role, startDateTime, endDateTime, predicate,
         pageable);
     return BaseResponse.of(200, HttpStatus.OK, "사용자 목록이 조회되었습니다.", response);
   }


### PR DESCRIPTION
## 연관된 이슈
Close #[이슈번호]

## 작업 내역
- username의 경우 사용자에게 입력받은 키워드를 포함하는 username을 가진 사용자 조회
- email의 경우 사용자에게 입력받은 키워드를 포함하는 email을 가진 사용자 조회
- role을 입력 받아서 해당 role을 가진 사용자를 조회
- startDate(시작날짜), endDate(종료날짜)를 yyyy-mm-dd 형식으로 입력받아 해당 기간동안에 가입한 사용자들은 조회
- 모든 필터는 선택 사항이며, 필요한 필터만 적용 가능
- 컨트롤러의 @Pathvariable 에 ("userId") 또는 ("username")이라고 명시해둠

## 테스트
- [x] API 테스트 
- [ ] 테스트 코드 작성

## 문제 및 해결
검색 필터를 적용하고자 따로 불리언빌더를 커스텀으로 만들었는데, 그럴 필요없이 repositoryCustonImpl에 조건만 더 추가하면 되는 것이었음

## 다음 진행사항

## 리뷰 요구사항
