### PR TITLE
[Feat/elk] Elastic Search를 통한 상품 조회 기능 추가

### DIFF
--- a/com.trillionares.tryit.gateway/build.gradle
+++ b/com.trillionares.tryit.gateway/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
+	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/com.trillionares.tryit.image-manage/src/main/java/com/trillionares/tryit/image_manage/domain/service/ImageEndpoint.java
+++ b/com.trillionares.tryit.image-manage/src/main/java/com/trillionares/tryit/image_manage/domain/service/ImageEndpoint.java
@@ -3,6 +3,7 @@ package com.trillionares.tryit.image_manage.domain.service;
 import com.trillionares.tryit.image_manage.domain.common.json.JsonUtils;
 import com.trillionares.tryit.image_manage.presentation.dto.ImageIdResponseDto;
 import com.trillionares.tryit.image_manage.presentation.dto.ImageInfoResquestDto;
+import com.trillionares.tryit.image_manage.presentation.dto.ImageUrlDto;
 import com.trillionares.tryit.image_manage.presentation.dto.ProductIdAndProductImageIdDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,11 +26,12 @@ public class ImageEndpoint {
         ImageInfoResquestDto resquestDto = JsonUtils.fromJson(message, ImageInfoResquestDto.class);
 
         ImageIdResponseDto responseDto = imageService.createImage(resquestDto);
+        ImageUrlDto imageUrlDto = imageService.getImageUrlById(responseDto.getImageId());
 
         log.info("Image ID: {}", responseDto.getImageId());
 
 
-        ProductIdAndProductImageIdDto pidAndPimgidDto = ProductIdAndProductImageIdDto.of(resquestDto.getProductId(), responseDto.getImageId());
+        ProductIdAndProductImageIdDto pidAndPimgidDto = ProductIdAndProductImageIdDto.of(resquestDto.getProductId(), responseDto.getImageId(), imageUrlDto.getImageUrl());
 
         String json = JsonUtils.toJson(pidAndPimgidDto);
         kafkaTemplate.send("updateImageIdOfProduct", json);

--- a/com.trillionares.tryit.image-manage/src/main/java/com/trillionares/tryit/image_manage/presentation/dto/ProductIdAndProductImageIdDto.java
+++ b/com.trillionares.tryit.image-manage/src/main/java/com/trillionares/tryit/image_manage/presentation/dto/ProductIdAndProductImageIdDto.java
@@ -13,11 +13,13 @@ import lombok.NoArgsConstructor;
 public class ProductIdAndProductImageIdDto {
     private UUID productId;
     private UUID productImageId;
+    private String productImgUrl;
 
-    public static ProductIdAndProductImageIdDto of(UUID productId, UUID imageId) {
+    public static ProductIdAndProductImageIdDto of(UUID productId, UUID imageId, String productImgUrl) {
         return ProductIdAndProductImageIdDto.builder()
             .productId(productId)
             .productImageId(imageId)
+            .productImgUrl(productImgUrl)
             .build();
     }
 }

--- a/com.trillionares.tryit.product/build.gradle
+++ b/com.trillionares.tryit.product/build.gradle
@@ -28,6 +28,10 @@ ext {
 }
 
 dependencies {
+	// ELK
+	implementation 'org.springframework.data:spring-data-elasticsearch:5.4.1'
+	implementation 'net.logstash.logback:logstash-logback-encoder:8.0' // Logback <-> Logstash 연동을 위함
+
 	// zipkin
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
@@ -59,7 +63,6 @@ dependencies {
 	implementation 'org.json:json:20230227'
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
 
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/ProductEndpoint.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/ProductEndpoint.java
@@ -1,7 +1,10 @@
 package com.trillionares.tryit.product.application.service;
 
+import com.trillionares.tryit.product.domain.client.ImageClient;
 import com.trillionares.tryit.product.domain.common.json.JsonUtils;
 import com.trillionares.tryit.product.domain.model.product.Product;
+import com.trillionares.tryit.product.domain.model.product.SearchProduct;
+import com.trillionares.tryit.product.domain.repository.ProductElasticSearchRepository;
 import com.trillionares.tryit.product.domain.repository.ProductRepository;
 import com.trillionares.tryit.product.presentation.dto.ProductIdAndProductImageIdDto;
 import java.util.Optional;
@@ -17,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProductEndpoint {
 
     private final ProductRepository productRepository;
+    private final ImageClient imageClient;
+    private final ProductElasticSearchRepository productElasticSearchRepository;
 
     @Transactional
     @KafkaListener(groupId = "productImageManagement", topics = "updateImageIdOfProduct")
@@ -34,5 +39,13 @@ public class ProductEndpoint {
         product.get().setProductImgId(pidAndPimgidDto.getProductImageId());
 
         productRepository.save(product.get());
+
+        if(productElasticSearchRepository.existsById(String.valueOf(product.get().getProductId()))) {
+            productElasticSearchRepository.deleteById(String.valueOf(product.get().getProductId()));
+
+            Optional<SearchProduct> searchProduct = productElasticSearchRepository.findById(String.valueOf(product.get().getProductId()));
+            searchProduct.get().updateImageInfo(pidAndPimgidDto.getProductImgUrl());
+            productElasticSearchRepository.save(searchProduct.get());
+        }
     }
 }

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/ProductService.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/ProductService.java
@@ -12,8 +12,10 @@ import com.trillionares.tryit.product.domain.model.product.ProductItem;
 import com.trillionares.tryit.product.domain.model.product.Product;
 import com.trillionares.tryit.product.domain.model.product.QProduct;
 import com.trillionares.tryit.product.domain.client.AuthClient;
+import com.trillionares.tryit.product.domain.model.product.SearchProduct;
 import com.trillionares.tryit.product.domain.repository.CategoryRepository;
 import com.trillionares.tryit.product.domain.repository.ProductCategoryRepository;
+import com.trillionares.tryit.product.domain.repository.ProductElasticSearchRepository;
 import com.trillionares.tryit.product.domain.repository.ProductItemRepository;
 import com.trillionares.tryit.product.domain.repository.ProductRepository;
 import com.trillionares.tryit.product.presentation.dto.ProductInfoToProductItemDto;
@@ -58,6 +60,7 @@ public class ProductService {
     private final ProductItemRepository productItemRepository;
     private final CategoryRepository categoryRepository;
     private final ProductCategoryRepository productCategoryRepository;
+    private final ProductElasticSearchRepository productElasticSearchRepository;
 
     private final ImageClient imageClient;
     private final AuthClient authClient;
@@ -507,5 +510,4 @@ public class ProductService {
         ProductIdResponseDto responseDto = ProductIdResponseDto.from(product.getProductId());
         return responseDto;
     }
-
 }

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/ProductService.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/ProductService.java
@@ -360,6 +360,13 @@ public class ProductService {
             productItemRepository.save(ProductInfoToProductItemDto.from(productInfoResponseDto));
         }
 
+        if(productElasticSearchRepository.existsById(String.valueOf(productId))) {
+            productElasticSearchRepository.deleteById(String.valueOf(productId));
+
+            String mainImgUrl = imageClient.getImageUrlById(product.getProductImgId()).getData().getImageUrl();
+            productElasticSearchRepository.save(productToSearchProduct(product, username, mainImgUrl));
+        }
+
         return responseDto;
     }
 

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/ProductService.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/ProductService.java
@@ -117,6 +117,8 @@ public class ProductService {
         } catch (Exception e) {
             throw new RuntimeException("직렬화 실패");
         }
+
+        productElasticSearchRepository.save(productToSearchProduct(product, username, productMainImageUrl.getImageUrl()));
         return product;
     }
 
@@ -148,8 +150,25 @@ public class ProductService {
         productRepository.save(product);
         productCategoryRepository.save(productCategory);
 
+        String mainImgUrl = imageClient.getImageUrlById(product.getProductImgId()).getData().getImageUrl();
+        productElasticSearchRepository.save(productToSearchProduct(product, username, mainImgUrl));
+
         ProductIdResponseDto responseDto = ProductIdResponseDto.from(product.getProductId());
         return responseDto;
+    }
+
+    private SearchProduct productToSearchProduct(Product product, String username, String mainImgUrl) {
+        return SearchProduct.builder()
+                .productId(String.valueOf(product.getProductId()))
+                .userId(String.valueOf(product.getUserId()))
+                .seller(username)
+                .productName(product.getProductName())
+                .productContent(product.getProductContent())
+                .productImgUrl(mainImgUrl)
+                .contentImgId(null)
+                .category(product.getProductCategory().getCategory().getCategoryName())
+                .content(product.getProductContent())
+                .build();
     }
 
     private Boolean validatePermission(String role) {

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/ProductService.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/ProductService.java
@@ -500,6 +500,10 @@ public class ProductService {
             productItemRepository.deleteById(String.valueOf(productId));
         }
 
+        if(productElasticSearchRepository.existsById(String.valueOf(productId))) {
+            productElasticSearchRepository.deleteById(String.valueOf(productId));
+        }
+
         ProductIdResponseDto responseDto = ProductIdResponseDto.from(product.getProductId());
         return responseDto;
     }

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/SearchProductServiceImpl.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/application/service/SearchProductServiceImpl.java
@@ -1,0 +1,80 @@
+package com.trillionares.tryit.product.application.service;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import com.trillionares.tryit.product.domain.model.product.SearchProduct;
+import com.trillionares.tryit.product.presentation.dto.response.ProductInfoResponseDto;
+import java.util.List;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class SearchProductServiceImpl {
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    public SearchProductServiceImpl(ElasticsearchOperations elasticsearchOperations){
+        this.elasticsearchOperations = elasticsearchOperations;
+    }
+
+    public List<ProductInfoResponseDto> search(String productName, String productId, String userId, String seller,
+                                               String productContent, String category) {
+        NativeQueryBuilder query = NativeQuery.builder();
+        BoolQuery.Builder boolQuery = QueryBuilders.bool();
+
+        // 1. productName 문자열 포함 조건
+        if (productName != null) {
+            boolQuery.must(QueryBuilders.queryString(field ->
+                    field.fields("productName").query("*%s*".formatted(productName))));
+        }
+
+        if (productId != null) {
+            boolQuery.filter(QueryBuilders.term(t -> t.field("productId").value(userId)));
+        }
+
+        // 2. userId 조건 (정확히 일치)
+        if (userId != null) {
+            boolQuery.filter(QueryBuilders.term(t -> t.field("userId").value(userId)));
+        }
+
+        // 3. seller 조건 (정확히 일치)
+        if (seller != null && !seller.isEmpty()) {
+            boolQuery.filter(QueryBuilders.term(t -> t.field("seller").value(seller)));
+        }
+
+        // 4. productContent 조건 (포함 여부)
+        if (productContent != null && !productContent.isEmpty()) {
+            boolQuery.must(QueryBuilders.match(m -> m.field("productContent").query(productContent)));
+        }
+
+        // 5. category 조건 (정확히 일치)
+        if (category != null && !category.isEmpty()) {
+            boolQuery.filter(QueryBuilders.term(t -> t.field("category").value(category)));
+        }
+
+        query.withQuery(boolQuery.build()._toQuery());
+        SearchHits<SearchProduct> hits = elasticsearchOperations.search(query.build(), SearchProduct.class);
+        log.info("get products productName: {}, userId: {}, seller: {}, productContent: {}, category: {}",
+                productName, userId, seller, productContent, category);
+        return hits.map(hit -> toDto(hit.getContent())).toList();
+    }
+
+    private static ProductInfoResponseDto toDto(SearchProduct product){
+        return ProductInfoResponseDto.builder()
+                .productId(UUID.fromString(product.getProductId()))
+                .name(product.getProductName())
+                .userId(UUID.fromString(product.getUserId()))
+                .seller(product.getSeller())
+                .content(product.getContent())
+                .category(product.getCategory())
+                .mainProductImgUrl(product.getProductImgUrl())
+                .contentImgUrlList(null)
+                .build();
+
+    }
+}

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/model/product/SearchProduct.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/model/product/SearchProduct.java
@@ -1,0 +1,38 @@
+package com.trillionares.tryit.product.domain.model.product;
+
+import jakarta.persistence.Column;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Document(indexName = "product")
+public class SearchProduct {
+    @Id
+    private String productId;
+    private String userId;
+    private String seller;
+    private String productName;
+    private String productContent;
+    private String productImgUrl;
+    private String contentImgId;
+    private String category;
+    private String content;
+
+    public void updateImageInfo(String productImgUrl) {
+        this.productImgUrl = productImgUrl;
+    }
+}

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/repository/ProductElasticSearchRepository.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/domain/repository/ProductElasticSearchRepository.java
@@ -1,0 +1,7 @@
+package com.trillionares.tryit.product.domain.repository;
+
+import com.trillionares.tryit.product.domain.model.product.SearchProduct;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface ProductElasticSearchRepository extends ElasticsearchRepository<SearchProduct, String> {
+}

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/infrastructure/config/ElasticConfig.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/infrastructure/config/ElasticConfig.java
@@ -1,0 +1,30 @@
+package com.trillionares.tryit.product.infrastructure.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+
+@Configuration
+public class ElasticConfig extends ElasticsearchConfiguration {
+
+    private final String hostUrl;
+    private final String username;
+    private final String password;
+
+    public ElasticConfig(@Value("${spring.data.elasticsearch.host}") String hostUrl,
+                         @Value("${spring.data.elasticsearch.username}") String username,
+                         @Value("${spring.data.elasticsearch.password}") String password) {
+        this.hostUrl = hostUrl;
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+                .connectedTo(hostUrl)
+                .withBasicAuth(username, password)
+                .build();
+    }
+}

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/ProductController.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/ProductController.java
@@ -2,6 +2,7 @@ package com.trillionares.tryit.product.presentation.controller;
 
 import com.querydsl.core.types.Predicate;
 import com.trillionares.tryit.product.application.service.ProductService;
+import com.trillionares.tryit.product.application.service.SearchProductServiceImpl;
 import com.trillionares.tryit.product.domain.common.json.JsonUtils;
 import com.trillionares.tryit.product.domain.common.message.ProductMessage;
 import com.trillionares.tryit.product.domain.model.product.Product;
@@ -41,6 +42,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ProductController {
 
     private final ProductService productService;
+    private final SearchProductServiceImpl searchProductService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BaseResponseDto<ProductIdResponseDto> createProduct(

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/ProductController.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/controller/ProductController.java
@@ -57,7 +57,7 @@ public class ProductController {
         } catch (CategoryNotFoundException cnfe) {
             return BaseResponseDto.from(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND, cnfe.getMessage(), null);
         } catch (RuntimeException re){
-            return BaseResponseDto.from(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR, ProductMessage.NOT_DEFINED_SERVER_RUNTIME_ERROR.getMessage(), null);
+            return BaseResponseDto.from(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR, re.getMessage(), null);
         } catch  (Exception e) {
             return BaseResponseDto.from(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR, ProductMessage.NOT_DEFINED_SERVER_ERROR.getMessage(), null);
         }
@@ -78,7 +78,7 @@ public class ProductController {
         } catch (CategoryNotFoundException cnfe) {
             return BaseResponseDto.from(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND, cnfe.getMessage(), null);
         } catch (RuntimeException re){
-            return BaseResponseDto.from(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR, ProductMessage.NOT_DEFINED_SERVER_RUNTIME_ERROR.getMessage(), null);
+            return BaseResponseDto.from(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR, re.getMessage(), null);
         } catch  (Exception e) {
             return BaseResponseDto.from(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR, ProductMessage.NOT_DEFINED_SERVER_ERROR.getMessage(), null);
         }
@@ -144,6 +144,24 @@ public class ProductController {
             return BaseResponseDto.from(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR, ProductMessage.NOT_DEFINED_SERVER_ERROR.getMessage(), null);
         }
     }
+
+    @GetMapping("/elk")
+    public BaseResponseDto<List<ProductInfoResponseDto>> getProductsUsingElk(
+            @RequestParam(value = "productName", required = false) String productName,
+            @RequestParam(value = "productId", required = false) String productId,
+            @RequestParam(value = "userId", required = false) String userId,
+            @RequestParam(value = "seller", required = false) String seller,
+            @RequestParam(value = "productContent", required = false) String productContent,
+            @RequestParam(value = "category", required = false) String category
+    ) {
+        try {
+            List<ProductInfoResponseDto> response = searchProductService.search(productName, productId, userId, seller, productContent, category);
+            return BaseResponseDto.from(HttpStatus.OK.value(), HttpStatus.OK, "ELK 검색 성공", response);
+        } catch (RuntimeException re) {
+            return BaseResponseDto.from(HttpStatus.OK.value(), HttpStatus.OK, re.getMessage(), null);
+        }
+    }
+
 
     @PutMapping("/{productId}")
     public BaseResponseDto<ProductIdResponseDto> updateProduct(

--- a/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/ProductIdAndProductImageIdDto.java
+++ b/com.trillionares.tryit.product/src/main/java/com/trillionares/tryit/product/presentation/dto/ProductIdAndProductImageIdDto.java
@@ -11,4 +11,5 @@ import lombok.NoArgsConstructor;
 public class ProductIdAndProductImageIdDto {
     private UUID productId;
     private UUID productImageId;
+    private String productImgUrl;
 }

--- a/com.trillionares.tryit.product/src/main/resources/application.yml
+++ b/com.trillionares.tryit.product/src/main/resources/application.yml
@@ -14,6 +14,12 @@ spring:
       port: ${PRODUCT_REDIS_PORT}
       username: ${REDIS_USERNAME}
       password: ${REDIS_PASSWORD}
+    elasticsearch:
+      host: ${ELK_URL}
+      username: ${ELK_USERNAME}
+      password: ${ELK_PASSWORD}
+      repositories:
+        enabled: true
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:

--- a/com.trillionares.tryit.product/src/main/resources/logback-spring.xml
+++ b/com.trillionares.tryit.product/src/main/resources/logback-spring.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration scan="true" scanPeriod="30 seconds">
+    <!-- 콘솔에 로그 출력 형식 지정 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} springboot-elk [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Logstash로 로그 전송 -->
+    <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <param name="Encoding" value="UTF-8"/>
+        <destination>${ELK_HOST}:50000</destination>
+
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp>
+                    <timeZone>UTC</timeZone>
+                </timestamp>
+                <logLevel />
+                <threadName />
+                <loggerName />
+                <message />
+                <stackTrace />
+            </providers>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="LOGSTASH" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
## 연관된 이슈
Close #280

## 작업 내역
- ELK를 위한 설정 추가
- 조회 endpoint 추가
  - 상품명, 등록한 사람 이름, 등록한 사람 PK, 상품 설명, 카테고리로 조회
- ELK에 사용한 Entity 정의
- 상품 등록 시 ELK에 상품 정보 추가 로직 추가
- 상품 수정 시 ELK에 상품 정보 수정 로직 추가
- 상품 삭제 시 ELK에 상품 정보 삭제 로직 추가

## 테스트
- [x] API 테스트 
- [ ] 테스트 코드 작성

## 문제 및 해결
(작업 중 발생한 문제와 그 해결 방법에 대해 간단히 설명해주세요.)

## 다음 진행사항

## 리뷰 요구사항
