### PR TITLE
Fix/retry notification 알림 발송 실패시 이벤트 재사용 위해 트랜잭션 아웃박스 패턴 적용

### DIFF
--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/NotificationApplication.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/NotificationApplication.java
@@ -3,9 +3,11 @@ package com.trillionares.tryit.notification;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableScheduling
 public class NotificationApplication {
 
 	public static void main(String[] args) {

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/application/dto/slack/SlackNotificationSender.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/application/dto/slack/SlackNotificationSender.java
@@ -1,13 +1,10 @@
 package com.trillionares.tryit.notification.application.dto.slack;
 
 import com.trillionares.tryit.notification.domain.model.Notification;
-import com.trillionares.tryit.notification.infrastructure.persistence.NotificationRepository;
-import com.trillionares.tryit.notification.libs.exception.ExceptionConverter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 @Slf4j
@@ -19,25 +16,21 @@ public class SlackNotificationSender {
   private String webhookUrl;
 
   private final RestTemplate restTemplate;
-  private final NotificationRepository notificationRepository;
-  private final ExceptionConverter exceptionConverter;
 
-  public void sendNotification(Notification notification, String slackId, String status) {
+  public boolean sendNotification(Notification notification, String slackId, String status) {
+    log.info("Slack API 호출 시작 - messageId: {}", notification.getMessageId());
 
     SlackMessage message = SlackMessage.from(notification, slackId, status); // 슬랙 메세지 생성
 
     try {
       restTemplate.postForEntity(webhookUrl, message, String.class);
-
-      notification.markAsDelivered();
-      log.info("Slack notification sent successfully: {}", notification.getNotificationId());
+      log.info("Slack API 호출 성공 - messageId: {}", notification.getMessageId());
+      return true;
 
     } catch (Exception e) {
-      notification.increaseAttemptCount();
-      notificationRepository.save(notification); // 실패의 경우도 저장
-      log.error("Failed to send Slack notification: {}", e.getMessage());
-
-       throw exceptionConverter.convertToBaseException(e);
+      log.error("Slack API 호출 실패 - messageId: {}, error: {}",
+          notification.getMessageId(), e.getMessage());
+      return false;
     }
   }
 }

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/application/service/NotificationEventService.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/application/service/NotificationEventService.java
@@ -1,0 +1,49 @@
+package com.trillionares.tryit.notification.application.service;
+
+import com.trillionares.tryit.notification.domain.model.NotificationOutbox;
+import com.trillionares.tryit.notification.domain.repository.NotificationOutboxRepository;
+import com.trillionares.tryit.notification.infrastructure.messaging.event.KafkaMessage;
+import com.trillionares.tryit.notification.infrastructure.messaging.event.SubmissionKafkaEvent;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationEventService {
+
+  private final NotificationOutboxRepository outboxRepository;
+  private final NotificationService notificationService;
+
+  @Transactional
+  public void processSubmissionNotification(KafkaMessage message, SubmissionKafkaEvent event) {
+    log.info("이벤트 처리 시작 - messageId: {}", message.getMessageId());
+
+    // outbox에 이벤트 저장
+    NotificationOutbox outbox = NotificationOutbox.builder()
+        .message(message)
+        .event(event)
+        .build();
+    outboxRepository.save(outbox);
+
+    try {
+      boolean success = notificationService.createNotificationFromSubmissionEvent(event);
+
+      if (success) {
+        outbox.markAsProcessed();
+        log.info("이벤트 처리 성공 - messageId: {}", message.getMessageId());
+      } else {
+        outbox.markAsFailed();
+        log.warn("이벤트 처리 실패 - messageId: {}", message.getMessageId());
+      }
+      outboxRepository.save(outbox);
+
+    } catch (Exception e) {
+      outbox.markAsFailed(); // 재시도 카운트 증가 및 상태 업데이트
+      outboxRepository.save(outbox); // 변경사항 저장
+      log.error("이벤트 처리 예외 - messageID: {}, ERROR: {}", message.getMessageId(), e.getMessage());
+    }
+  }
+}

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/application/service/NotificationService.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/application/service/NotificationService.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -34,16 +35,51 @@ public class NotificationService {
 
   /**
    * Kafka 이벤트를 기반으로 알림을 생성하고 Slack으로 발송합니다.
+   *
    * @param event 체험단 신청(submission) 카프카 이벤트를 통해 받아온 값
+   * @return
    */
   @Transactional
-  public void createNotificationFromSubmissionEvent(SubmissionKafkaEvent event) {
+  public boolean createNotificationFromSubmissionEvent(SubmissionKafkaEvent event) {
 
     validateNotification(event);
     Notification notification = notificationRepository.save(
         convertEventToNotification(event));
 
-    sendNotificationToSlack(notification, event.getStatus());
+    return sendNotificationToSlack(notification.getNotificationId(), event.getStatus());
+  }
+
+  /**
+   * 생성된 알림을 Slack으로 발송합니다.
+   * @param notificationId 알림 고유 ID
+   * @param status 알림 상태 정보
+   */
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public boolean sendNotificationToSlack(UUID notificationId, String status) {
+
+    Notification notification = notificationRepository.findById(notificationId)
+        .orElseThrow(() -> new GlobalException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+    try {
+      String slackId = getSlackId(notification);
+
+      boolean result = slackNotificationSender.sendNotification(notification, slackId, status);
+      if (result) {
+        notification.markAsDelivered();
+      } else {
+        notification.increaseAttemptCount();
+      }
+      notificationRepository.save(notification);
+      return result;
+
+    } catch (Exception e) {
+      notification.increaseAttemptCount();
+      notificationRepository.save(notification);
+      log.error("알림 발송 실패, attempt {}: {}",
+          notification.getAttemptCount(), e.getMessage());
+      return false;
+    }
   }
 
   /**
@@ -68,25 +104,6 @@ public class NotificationService {
     if (notification.getAttemptCount() >= 3) {
       log.warn("재시도 횟수 3회 초과 {}", notification.getMessageId());
       throw new GlobalException(ErrorCode.MAX_RETRY_EXCEEDED);
-    }
-  }
-
-  /**
-   * 생성된 알림을 Slack으로 발송합니다.
-   * @param notification 알림 객체
-   * @param status 알림 상태 정보
-   */
-  private void sendNotificationToSlack(Notification notification, String status) {
-    try {
-      String slackId = getSlackId(notification);
-      slackNotificationSender.sendNotification(notification, slackId, status);
-      notification.markAsDelivered();
-
-    } catch (Exception e) {
-      notification.increaseAttemptCount();
-      log.error("알림 발송 실패, attempt {}: {}",
-          notification.getAttemptCount(), e.getMessage());
-      throw e;
     }
   }
 
@@ -116,7 +133,6 @@ public class NotificationService {
    * @return 생성된 알림 데이터
    */
   private Notification convertEventToNotification(SubmissionKafkaEvent event) {
-
     return Notification.builder()
         .userId(event.getUserId())
         .submissionId(event.getSubmissionId())

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/domain/model/Notification.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/domain/model/Notification.java
@@ -54,16 +54,16 @@ public class Notification extends BaseEntity {
     this.expiryDate = LocalDateTime.now().plusMonths(3); // 저장일로 부터 3개월
   }
 
-  public void increaseAttemptCount() {
-    this.attemptCount++;
-    updateNotificationStatus();
-  }
-
   public void markAsDelivered() {
     this.notificationStatus = NotificationStatus.SENT;
   }
 
-  public void updateNotificationStatus() {
+  public void increaseAttemptCount() {
+    this.attemptCount++;
+    updateStatus();
+  }
+
+  public void updateStatus() {
     if (this.attemptCount >= MAX_ATTEMPT_COUNT) {
       this.notificationStatus = NotificationStatus.FAILED; // 시도 횟수 3번 이상 실패
 

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/domain/model/NotificationOutbox.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/domain/model/NotificationOutbox.java
@@ -55,6 +55,8 @@ public class NotificationOutbox extends BaseEntity {
     this.retryCount++;
     if (this.retryCount >= 3) {
       this.outboxStatus = NotificationStatus.FAILED;
+    } else {
+      this.outboxStatus = NotificationStatus.PENDING;
     }
   }
 

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/domain/model/NotificationOutbox.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/domain/model/NotificationOutbox.java
@@ -1,0 +1,76 @@
+package com.trillionares.tryit.notification.domain.model;
+
+import com.trillionares.tryit.notification.domain.common.base.BaseEntity;
+import com.trillionares.tryit.notification.infrastructure.messaging.event.KafkaMessage;
+import com.trillionares.tryit.notification.infrastructure.messaging.event.SubmissionKafkaEvent;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationOutbox extends BaseEntity {
+
+  @Id
+  @Column(name = "notification_id", updatable = false)
+  private UUID eventId;
+
+  @Column(name = "message_id", nullable = false)
+  private String messageId;
+
+  @Column(nullable = false)
+  private UUID submissionId;
+
+  @Column(nullable = false)
+  private UUID userId;
+
+  @Column(nullable = false)
+  private UUID recruitmentId;
+
+  @Column(nullable = false)
+  private String status;
+
+  private int retryCount;
+
+  @Enumerated(EnumType.STRING)
+  private NotificationStatus outboxStatus;
+
+  private LocalDateTime processedAt;
+
+  public void markAsProcessed() {
+    this.outboxStatus = NotificationStatus.SENT;
+    this.processedAt = LocalDateTime.now();
+  }
+
+  public void markAsFailed() {
+    this.retryCount++;
+    if (this.retryCount >= 3) {
+      this.outboxStatus = NotificationStatus.FAILED;
+    }
+  }
+
+  public boolean canRetry() {
+    return this.retryCount < 3 && this.outboxStatus != NotificationStatus.SENT;
+  }
+
+  @Builder
+  public NotificationOutbox(KafkaMessage message, SubmissionKafkaEvent event) {
+    this.eventId = UUID.fromString(message.getMessageId());
+    this.messageId = message.getMessageId();
+    this.submissionId = event.getSubmissionId();
+    this.userId = event.getUserId();
+    this.recruitmentId = event.getRecruitmentId();
+    this.status = event.getStatus();
+    this.outboxStatus = NotificationStatus.PENDING;
+    this.retryCount = 0;
+  }
+}

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/domain/model/NotificationOutbox.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/domain/model/NotificationOutbox.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 public class NotificationOutbox extends BaseEntity {
 
   @Id
-  @Column(name = "notification_id", updatable = false)
+  @Column(name = "event_id", updatable = false)
   private UUID eventId;
 
   @Column(name = "message_id", nullable = false)

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/domain/repository/NotificationOutboxRepository.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/domain/repository/NotificationOutboxRepository.java
@@ -1,0 +1,12 @@
+package com.trillionares.tryit.notification.domain.repository;
+
+import com.trillionares.tryit.notification.domain.model.NotificationOutbox;
+import com.trillionares.tryit.notification.domain.model.NotificationStatus;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationOutboxRepository extends JpaRepository<NotificationOutbox, UUID> {
+
+  List<NotificationOutbox> findByOutboxStatus(NotificationStatus status);
+}

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/infrastructure/messaging/event/SubmissionEventConsumer.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/infrastructure/messaging/event/SubmissionEventConsumer.java
@@ -2,7 +2,7 @@ package com.trillionares.tryit.notification.infrastructure.messaging.event;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.trillionares.tryit.notification.application.service.NotificationService;
+import com.trillionares.tryit.notification.application.service.NotificationEventService;
 import com.trillionares.tryit.notification.libs.exception.ErrorCode;
 import com.trillionares.tryit.notification.libs.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SubmissionEventConsumer {
 
-  private final NotificationService notificationService;
+  private final NotificationEventService notificationEventService; // 추가
   private final ObjectMapper objectMapper;
 
   @KafkaListener(
@@ -23,7 +23,7 @@ public class SubmissionEventConsumer {
       groupId = "${spring.kafka.consumer.group-id}"
   )
 
-  public void handleSubmissionEvent(String message) {
+  public void consumeSubmissionEvent(String message) {
     try {
       KafkaMessage kafkaMessage = objectMapper.readValue(message, KafkaMessage.class);
 
@@ -36,7 +36,8 @@ public class SubmissionEventConsumer {
       event.setMessageId(kafkaMessage.getMessageId());
       log.info("두번째 역직렬화 SubmissionKafkaEvent: {}", event);
 
-      notificationService.createNotificationFromSubmissionEvent(event);
+      notificationEventService.processSubmissionNotification(kafkaMessage, event);
+
     } catch (JsonProcessingException e) {
       log.error("Failed to process kafka message: {}", message, e);
 

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/infrastructure/messaging/event/SubmissionKafkaEvent.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/infrastructure/messaging/event/SubmissionKafkaEvent.java
@@ -1,20 +1,36 @@
 package com.trillionares.tryit.notification.infrastructure.messaging.event;
 
+import com.trillionares.tryit.notification.domain.model.NotificationOutbox;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 
-@ToString
 @Getter
 public class SubmissionKafkaEvent {
 
-  private UUID submissionId;
-  private UUID userId;
-  private UUID recruitmentId;
-  private String status;
-
+  private final UUID submissionId;
+  private final UUID userId;
+  private final UUID recruitmentId;
+  private final String status;
   @Setter
   private String messageId;
 
+  private SubmissionKafkaEvent(UUID submissionId, UUID userId, UUID recruitmentId,
+      String status, String messageId) {
+    this.submissionId = submissionId;
+    this.userId = userId;
+    this.recruitmentId = recruitmentId;
+    this.status = status;
+    this.messageId = messageId;
+  }
+
+  public static SubmissionKafkaEvent from(NotificationOutbox outbox) {
+    return new SubmissionKafkaEvent(
+        outbox.getSubmissionId(),
+        outbox.getUserId(),
+        outbox.getRecruitmentId(),
+        outbox.getStatus(),
+        outbox.getMessageId()
+    );
+  }
 }

--- a/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/infrastructure/scheduler/NotificationOutboxScheduler.java
+++ b/com.trillionares.tryit.notification/src/main/java/com/trillionares/tryit/notification/infrastructure/scheduler/NotificationOutboxScheduler.java
@@ -1,0 +1,60 @@
+package com.trillionares.tryit.notification.infrastructure.scheduler;
+
+import com.trillionares.tryit.notification.application.service.NotificationService;
+import com.trillionares.tryit.notification.domain.model.NotificationOutbox;
+import com.trillionares.tryit.notification.domain.model.NotificationStatus;
+import com.trillionares.tryit.notification.domain.repository.NotificationOutboxRepository;
+import com.trillionares.tryit.notification.infrastructure.messaging.event.SubmissionKafkaEvent;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationOutboxScheduler {
+
+  private final NotificationOutboxRepository notificationOutboxRepository;
+  private final NotificationService notificationService;
+
+  @Scheduled(fixedDelayString = "${notification.retry.delay:10000}")
+  public void processFailedNotifications() {
+    log.info("알림 재시도 스케줄러 실행");
+
+    List<NotificationOutbox> pendingOutboxes = notificationOutboxRepository
+        .findByOutboxStatus(NotificationStatus.PENDING);
+
+    if (!pendingOutboxes.isEmpty()) {
+      log.info("알림 재처리 시작 - 대상 수: {}", pendingOutboxes.size());
+
+      for (NotificationOutbox outbox : pendingOutboxes) {
+
+        if (!outbox.canRetry()) {
+          continue;
+        }
+
+        try {
+          // 알림 처리
+          boolean success =
+              notificationService.sendNotificationToSlack(outbox.getEventId(), outbox.getStatus());
+
+          if (success) { // 성공 처리
+            outbox.markAsProcessed();
+            log.info("알림 재처리 성공 - messageId: {}", outbox.getMessageId());
+          } else {
+            outbox.markAsFailed();
+            log.warn("알림 재처리 실패 - messageId: {}, 시도 횟수: {}/3",
+                outbox.getMessageId(), outbox.getRetryCount());
+          }
+        } catch (Exception e) {
+          outbox.markAsFailed();
+          log.error("알림 재처리 중 예외 발생 - messageId: {}, 시도 횟수: {}/3, 오류: {}",
+              outbox.getMessageId(), outbox.getRetryCount(), e.getMessage());
+        }
+        notificationOutboxRepository.save(outbox);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 연관된 이슈
Close #296 

## 작업 내역
`AS-IS`
알림 재시도를 실패했을때 재시도 하는 로직은 있지만 이벤트가 재처리 되지 않고 실제 시도되지 않음

`TO-BE`
체험단 신청에서 넘어오는 이벤트ID를 알림 신청이 실패되었을 때 아웃박스 패턴을 사용해 이벤트를 저장하고 재사용할 수 있도록 개선
스케줄러를 통해 3회이하인 경우 알림 발송 재시도 할 수 있도록 추가 개발

## 수정내역
- 아웃박스 엔티티에서 실패 가산하는 로직에서 3회 이하일때 PENDING으로 변경해 알림 전송 재시도 하도록 수정
- outbox 상태 조회하는 메서드를 NotificationOutboxRepository에 생성
- 알림 발송 실패시 재시도를 위한 스케줄러 생성
   -> 스케줄러에 시도 횟수가 3회 이하이고 PENDING 상태인 경우 재시도 하도록  함
- 알림 생성시 아웃박스에 이벤트 저장하는 서비스 로직 추가
- 트랜잭션 롤백이 아닌 이벤트 재사용 위해 알림 변환 로직 제거
- 체험단 신청 이벤트 받아 가공할때 outbox에도 함께 저장할 수 있도록 SubmissionKafkaEvent에 from 메서드 추가

## 테스트
```text
2025-03-14T02:22:38.724+09:00 ERROR 4993 --- [notification-service] [   scheduling-1] NotificationOutboxScheduler  : 알림 재처리 중 예외 발생 - messageId: e8821c0e-5dcd-47b4-ad15-b4054836fa09, 시도 횟수: 3/3
```

<img width="1330" alt="image" src="https://github.com/user-attachments/assets/8b4bf740-edbd-4bcc-a11c-48bff35c482f" />


## 문제 및 해결
- 아웃박스 엔티티에 저장되지 않고 임의로 20회가 시도되는 문제
  -> 예외 발생시 throw 하고 있었는데 이때 트랜잭션이 롤백되면서 엔티티에 저장되지 않는점 확인
 -> throw 하고 있는 부분을 제거하고 단일 트랜잭션 내에서 로직이 동작하도록 수정

## 다음 진행사항

## 리뷰 요구사항
